### PR TITLE
Multiple fixes for pkg.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -117,7 +117,7 @@ include full documentation
         return True
 
 
-    def audit(tags, verbose_failures=False):
+    def audit(tags, verbose=False):
         ret = {'Success': [], 'Failure': []}
         for tag in __tags__:
             if fnmatch.fnmatch(tag, tags):
@@ -132,14 +132,14 @@ compatibility, and an ``audit()`` function to perform the actual audit
 functionality
 
 The ``audit()`` function must take two arguments, ``tags`` and
-``verbose_failures``. The ``tags`` argument is a glob expression for which tags
+``verbose``. The ``tags`` argument is a glob expression for which tags
 the audit function should run. It is the job of the audit module to compare the
 ``tags`` glob with all tags supported by this module and only run the audits
-which match. The ``verbose_failures`` argument defines whether additional
-information should be returned for failures, such as description and
+which match. The ``verbose`` argument defines whether additional
+information should be returned for audits, such as description and
 remediation instructions.
 
 The return value should be a dictionary, with two keys, "Success" and
 "Failure".  The values for these keys should be a list of tags as strings, or a
 list of dictionaries containing tags and other information for the audit (in
-the case of ``verbose_failures``).
+the case of ``verbose``).

--- a/_modules/nova.py
+++ b/_modules/nova.py
@@ -34,7 +34,7 @@ from salt.loader import LazyLoader
 __nova__ = {}
 
 
-def audit(modules='', tag='*'):
+def audit(modules='', tag='*', verbose=False, show_success=True):
     '''
     Primary entry point for audit calls.
 
@@ -51,6 +51,15 @@ def audit(modules='', tag='*'):
         Glob pattern string for tags to include in the audit. This way you can
         give a directory, and tell the system to only run the `CIS*`-tagged
         audit modules, for example.
+
+    verbose
+        Whether to show additional information about audits, including
+        description, remediation instructions, etc. The data returned depends
+        on the audit module. Defaults to False.
+
+    show_success
+        Whether to show successful audits in addition to failed audits.
+        Defaults to True.
     '''
     if __salt__['config.get']('hubblestack.nova.autoload', True):
         load()
@@ -73,7 +82,7 @@ def audit(modules='', tag='*'):
         for key, func in __nova__._dict.iteritems():
             if key not in already_run and key.startswith(module):
                 # Found a match, run the audit
-                ret = func(tag)
+                ret = func(tag, verbose=verbose)
 
                 # Make sure we don't run the same audit twice
                 already_run.add(key)
@@ -81,6 +90,9 @@ def audit(modules='', tag='*'):
                 # Compile the results
                 results['Success'].extend(ret.get('Success', []))
                 results['Failure'].extend(ret.get('Failure', []))
+
+    if not show_success:
+        results.pop('Success')
 
     return results
 

--- a/hubblestack_nova/pkg.py
+++ b/hubblestack_nova/pkg.py
@@ -58,6 +58,7 @@ import logging
 import fnmatch
 import yaml
 import os
+import copy
 import salt.utils
 
 log = logging.getLogger(__name__)
@@ -118,8 +119,6 @@ def audit(tags, verbose=False):
         ret['Success'] = list(success)
         ret['Failure'] = list(failure)
 
-    if not show_success:
-        ret.pop('Success')
     return ret
 
 
@@ -172,8 +171,10 @@ def _get_tags(data):
                 for name, tag in item.iteritems():
                     if tag not in ret:
                         ret[tag] = []
-                    ret[tag].append({'name': name,
-                                     'tag': tag,
-                                     'type': toplist,
-                                     'data': audit_data})
+                    formatted_data = {'name': name,
+                                      'tag': tag,
+                                      'type': toplist}
+                    formatted_data.update(audit_data)
+                    formatted_data.pop('data')
+                    ret[tag].append(formatted_data)
     return ret

--- a/hubblestack_nova/pkg.py
+++ b/hubblestack_nova/pkg.py
@@ -77,32 +77,49 @@ def __virtual__():
     return True
 
 
-def audit(tags, verbose_failures=False):
+def audit(tags, verbose=False):
     '''
     Run the pkg audits contained in the YAML files processed by __virtual__
     '''
     ret = {'Success': [], 'Failure': []}
     for tag in __tags__:
         if fnmatch.fnmatch(tag, tags):
-            name = __tags__[tag]['name']
-            audittype = __tags__[tag]['type']
-            if audittype == 'blacklist':
-                if __salt__['pkg.version'](name):
-                    ret['Failure'].append(tag)
-                else:
-                    ret['Success'].append(tag)
-            elif audittype == 'whitelist':
-                if __salt__['pkg.version'](name):
-                    ret['Success'].append(tag)
-                else:
-                    ret['Failure'].append(tag)
-    if verbose_failures:
-        ret_extra = {'Success': {}, 'Failure': {}}
-        for tag in ret['Success']:
-            ret_extra['Success'][tag] = __tags__[tag]
-        for tag in ret['Failure']:
-            ret_extra['Failure'][tag] = __tags__[tag]
-        return ret_extra
+            for tag_data in __tags__[tag]:
+                name = tag_data['name']
+                audittype = tag_data['type']
+
+                # Blacklisted packages (must not be installed)
+                if audittype == 'blacklist':
+                    if __salt__['pkg.version'](name):
+                        ret['Failure'].append(tag_data)
+                    else:
+                        ret['Success'].append(tag_data)
+
+                # Whitelisted packages (must be installed)
+                elif audittype == 'whitelist':
+                    if __salt__['pkg.version'](name):
+                        ret['Success'].append(tag_data)
+                    else:
+                        ret['Failure'].append(tag_data)
+
+    if not verbose:
+        failure = set()
+        success = set()
+
+        for tag_data in ret['Failure']:
+            tag = tag_data['tag']
+            failure.add(tag)
+
+        for tag_data in ret['Success']:
+            tag = tag_data['tag']
+            if tag not in failure:
+                success.add(tag)
+
+        ret['Success'] = list(success)
+        ret['Failure'] = list(failure)
+
+    if not show_success:
+        ret.pop('Success')
     return ret
 
 
@@ -153,8 +170,10 @@ def _get_tags(data):
             # pkg:blacklist:telnet:data:Debian-8
             for item in tags:
                 for name, tag in item.iteritems():
-                    ret[tag] = {'name': name,
-                                'tag': tag,
-                                'type': toplist,
-                                'data': audit_data}
+                    if tag not in ret:
+                        ret[tag] = []
+                    ret[tag].append({'name': name,
+                                     'tag': tag,
+                                     'type': toplist,
+                                     'data': audit_data})
     return ret


### PR DESCRIPTION
1. Fixes issue where multiple packages with same tag could be ignored
2. Always returns successes and failures as a list
3. Change `verbose_failures` to `verbose` and add `show_success` arg
