### PR TITLE
Add configuration options and better default output

### DIFF
--- a/_modules/nova.py
+++ b/_modules/nova.py
@@ -36,9 +36,9 @@ __nova__ = {}
 
 def audit(modules='',
           tag='*',
-          verbose=False,
-          show_success=True,
-          show_compliance=True):
+          verbose=None,
+          show_success=None,
+          show_compliance=None):
     '''
     Primary entry point for audit calls.
 
@@ -59,20 +59,30 @@ def audit(modules='',
     verbose
         Whether to show additional information about audits, including
         description, remediation instructions, etc. The data returned depends
-        on the audit module. Defaults to False.
+        on the audit module. Defaults to False. Configurable via
+        `hubblestack.nova.verbose` in minion config/pillar.
 
     show_success
         Whether to show successful audits in addition to failed audits.
-        Defaults to True.
+        Defaults to True. Configurable via `hubblestack.nova.show_success` in
+        minion config/pillar.
 
     show_compliance
         Whether to show compliance as a percentage (successful checks divided
-        by total checks). Defaults to True.
+        by total checks). Defaults to True. Configurable via
+        `hubblestack.nova.show_compliance` in minion config/pillar.
     '''
     if __salt__['config.get']('hubblestack.nova.autoload', True):
         load()
     if not __nova__:
         return False, 'No nova modules have been loaded.'
+
+    if verbose is None:
+        verbose = __salt__['config.get']('hubblestack.nova.verbose', False)
+    if show_success is None:
+        show_success = __salt__['config.get']('hubblestack.nova.show_success', True)
+    if show_compliance is None:
+        show_compliance = __salt__['config.get']('hubblestack.nova.show_compliance', True)
 
     if not isinstance(modules, list):
         # Convert string

--- a/hubblestack_nova/grep.py
+++ b/hubblestack_nova/grep.py
@@ -99,20 +99,21 @@ def audit(tags, verbose=False):
                         ret['Failure'].append(tag_data)
 
     if not verbose:
-        failure = set()
-        success = set()
+        failure = []
+        success = []
 
         for tag_data in ret['Failure']:
             tag = tag_data['tag']
-            failure.add(tag)
+            description = tag_data.get('description')
+            failure.append({tag: description})
 
         for tag_data in ret['Success']:
             tag = tag_data['tag']
-            if tag not in failure:
-                success.add(tag)
+            description = tag_data.get('description')
+            success.append({tag: description})
 
-        ret['Success'] = list(success)
-        ret['Failure'] = list(failure)
+        ret['Success'] = success
+        ret['Failure'] = failure
 
     return ret
 

--- a/hubblestack_nova/pkg.py
+++ b/hubblestack_nova/pkg.py
@@ -155,20 +155,21 @@ def audit(tags, verbose=False):
                             ret['Failure'].append(tag_data)
 
     if not verbose:
-        failure = set()
-        success = set()
+        failure = []
+        success = []
 
         for tag_data in ret['Failure']:
             tag = tag_data['tag']
-            failure.add(tag)
+            description = tag_data.get('description')
+            failure.append({tag: description})
 
         for tag_data in ret['Success']:
             tag = tag_data['tag']
-            if tag not in failure:
-                success.add(tag)
+            description = tag_data.get('description')
+            success.append({tag: description})
 
-        ret['Success'] = list(success)
-        ret['Failure'] = list(failure)
+        ret['Success'] = success
+        ret['Failure'] = failure
 
     return ret
 

--- a/hubblestack_nova/service.py
+++ b/hubblestack_nova/service.py
@@ -106,20 +106,21 @@ def audit(tags, verbose=False):
                         ret['Failure'].append(tag_data)
 
     if not verbose:
-        failure = set()
-        success = set()
+        failure = []
+        success = []
 
         for tag_data in ret['Failure']:
             tag = tag_data['tag']
-            failure.add(tag)
+            description = tag_data.get('description')
+            failure.append({tag: description})
 
         for tag_data in ret['Success']:
             tag = tag_data['tag']
-            if tag not in failure:
-                success.add(tag)
+            description = tag_data.get('description')
+            success.append({tag: description})
 
-        ret['Success'] = list(success)
-        ret['Failure'] = list(failure)
+        ret['Success'] = success
+        ret['Failure'] = failure
 
     return ret
 

--- a/hubblestack_nova/stat.py
+++ b/hubblestack_nova/stat.py
@@ -66,20 +66,21 @@ def audit(tags, verbose=False):
                     ret['Failure'].append(tag_data)
 
     if not verbose:
-        failure = set()
-        success = set()
+        failure = []
+        success = []
 
         for tag_data in ret['Failure']:
             tag = tag_data['tag']
-            failure.add(tag)
+            description = tag_data.get('description')
+            failure.append({tag: description})
 
         for tag_data in ret['Success']:
             tag = tag_data['tag']
-            if tag not in failure:
-                success.add(tag)
+            description = tag_data.get('description')
+            success.append({tag: description})
 
-        ret['Success'] = list(success)
-        ret['Failure'] = list(failure)
+        ret['Success'] = success
+        ret['Failure'] = failure
 
     return ret
 


### PR DESCRIPTION
By default, output the description with the tags for audit successes/failures

Allow configuration of each of the audit options (verbose, show_success, show_compliance)
