### PR TITLE
Load yaml in hubble.py

### DIFF
--- a/hubblestack_nova/grep.py
+++ b/hubblestack_nova/grep.py
@@ -51,25 +51,22 @@ from distutils.version import LooseVersion
 
 log = logging.getLogger(__name__)
 
-__tags__ = None
-__data__ = None
-
 
 def __virtual__():
     if salt.utils.is_windows():
         return False, 'This audit module only runs on linux'
-    global __tags__
-    global __data__
-    yamldir = os.path.dirname(__file__)
-    __data__ = _get_yaml(yamldir)
-    __tags__ = _get_tags(__data__)
     return True
 
 
-def audit(tags, verbose=False):
+def audit(data_list, tags, verbose=False):
     '''
     Run the grep audits contained in the YAML files processed by __virtual__
     '''
+    __data__ = {}
+    for data in data_list:
+        _merge_yaml(__data__, data)
+    __tags__ = _get_tags(__data__)
+
     ret = {'Success': [], 'Failure': []}
     for tag in __tags__:
         if fnmatch.fnmatch(tag, tags):
@@ -140,23 +137,6 @@ def audit(tags, verbose=False):
         ret['Success'] = success
         ret['Failure'] = failure
 
-    return ret
-
-
-def _get_yaml(dirname):
-    '''
-    Iterate over the current directory for all yaml files, read them in,
-    merge them, and return the __data__
-    '''
-    ret = {}
-    try:
-        for yamlpath in os.listdir(dirname):
-            if yamlpath.endswith('.yaml'):
-                with open(os.path.join(dirname, yamlpath)) as fh_:
-                    data = yaml.safe_load(fh_)
-                _merge_yaml(ret, data)
-    except:
-        return {}
     return ret
 
 

--- a/hubblestack_nova/pkg.py
+++ b/hubblestack_nova/pkg.py
@@ -77,25 +77,22 @@ from distutils.version import LooseVersion
 
 log = logging.getLogger(__name__)
 
-__tags__ = None
-__data__ = None
-
 
 def __virtual__():
     if salt.utils.is_windows():
         return False, 'This audit module only runs on linux'
-    global __tags__
-    global __data__
-    yamldir = os.path.dirname(__file__)
-    __data__ = _get_yaml(yamldir)
-    __tags__ = _get_tags(__data__)
     return True
 
 
-def audit(tags, verbose=False):
+def audit(data_list, tags, verbose=False):
     '''
     Run the pkg audits contained in the YAML files processed by __virtual__
     '''
+    __data__ = {}
+    for data in data_list:
+        _merge_yaml(__data__, data)
+    __tags__ = _get_tags(__data__)
+
     ret = {'Success': [], 'Failure': []}
     for tag in __tags__:
         if fnmatch.fnmatch(tag, tags):
@@ -179,23 +176,6 @@ def audit(tags, verbose=False):
         ret['Success'] = success
         ret['Failure'] = failure
 
-    return ret
-
-
-def _get_yaml(dirname):
-    '''
-    Iterate over the current directory for all yaml files, read them in,
-    merge them, and return the __data__
-    '''
-    ret = {}
-    try:
-        for yamlpath in os.listdir(dirname):
-            if yamlpath.endswith('.yaml'):
-                with open(os.path.join(dirname, yamlpath)) as fh_:
-                    data = yaml.safe_load(fh_)
-                _merge_yaml(ret, data)
-    except:
-        return {}
     return ret
 
 

--- a/hubblestack_nova/pkgng_audit.py
+++ b/hubblestack_nova/pkgng_audit.py
@@ -12,22 +12,28 @@ import logging
 
 log = logging.getLogger(__name__)
 
-__tags__ = None
-
 
 def __virtual__():
     if 'FreeBSD' not in __grains__['os']:
         return False, 'This audit module only runs on FreeBSD'
-    global __tags__
-    __tags__ = ['freebsd-pkg-audit']
     return True
 
 
-def audit(tags, verbose=False):
+def audit(data_list, tags, verbose=False):
     '''
     Run the pkg.audit command
     '''
     ret = {'Success': [], 'Failure': []}
+
+    __tags__ = []
+    for data in data_list:
+        if 'freebsd-pkg' in data:
+            __tags__ = ['freebsd-pkg-audit']
+            break
+
+    if not __tags__:
+        # No yaml data found, don't do any work
+        return ret
 
     salt_ret = __salt__['pkg.audit']()
     if '0 problem(s)' not in salt_ret:

--- a/hubblestack_nova/pkgng_audit.py
+++ b/hubblestack_nova/pkgng_audit.py
@@ -27,8 +27,8 @@ def audit(data_list, tags, verbose=False):
 
     __tags__ = []
     for data in data_list:
-        if 'freebsd-pkg' in data:
-            __tags__ = ['freebsd-pkg-audit']
+        if 'pkgng_audit' in data:
+            __tags__ = ['pkgng_audit']
             break
 
     if not __tags__:

--- a/hubblestack_nova/pkgng_audit.yaml
+++ b/hubblestack_nova/pkgng_audit.yaml
@@ -1,0 +1,1 @@
+pkgng_audit: True

--- a/hubblestack_nova/service.py
+++ b/hubblestack_nova/service.py
@@ -65,25 +65,22 @@ from distutils.version import LooseVersion
 
 log = logging.getLogger(__name__)
 
-__tags__ = None
-__data__ = None
-
 
 def __virtual__():
     if salt.utils.is_windows():
         return False, 'This audit module only runs on linux'
-    global __tags__
-    global __data__
-    yamldir = os.path.dirname(__file__)
-    __data__ = _get_yaml(yamldir)
-    __tags__ = _get_tags(__data__)
     return True
 
 
-def audit(tags, verbose=False):
+def audit(data_list, tags, verbose=False):
     '''
     Run the service audits contained in the YAML files processed by __virtual__
     '''
+    __data__ = {}
+    for data in data_list:
+        _merge_yaml(__data__, data)
+    __tags__ = _get_tags(__data__)
+
     ret = {'Success': [], 'Failure': []}
     for tag in __tags__:
         if fnmatch.fnmatch(tag, tags):
@@ -130,23 +127,6 @@ def audit(tags, verbose=False):
         ret['Success'] = success
         ret['Failure'] = failure
 
-    return ret
-
-
-def _get_yaml(dirname):
-    '''
-    Iterate over the current directory for all yaml files, read them in,
-    merge them, and return the __data__
-    '''
-    ret = {}
-    try:
-        for yamlpath in os.listdir(dirname):
-            if yamlpath.endswith('.yaml'):
-                with open(os.path.join(dirname, yamlpath)) as fh_:
-                    data = yaml.safe_load(fh_)
-                _merge_yaml(ret, data)
-    except:
-        return {}
     return ret
 
 

--- a/hubblestack_nova/stat.py
+++ b/hubblestack_nova/stat.py
@@ -50,27 +50,22 @@ from distutils.version import LooseVersion
 
 log = logging.getLogger(__name__)
 
-__tags__ = None
-__data__ = None
-
 
 def __virtual__():
     if salt.utils.is_windows():
         return False, 'This audit module only runs on linux'
-    global __tags__
-    global __data__
-    yamldir = os.path.dirname(__file__)
-    if not yamldir:
-        yamldir = '.'
-    __data__ = _get_yaml(yamldir)
-    __tags__ = _get_tags(__data__)
     return True
 
 
-def audit(tags, verbose=False):
+def audit(data_list, tags, verbose=False):
     '''
     Run the stat audits contained in the YAML files processed by __virtual__
     '''
+    __data__ = {}
+    for data in data_list:
+        _merge_yaml(__data__, data)
+    __tags__ = _get_tags(__data__)
+
     ret = {'Success': [], 'Failure': []}
 
     for tag in __tags__:
@@ -143,23 +138,6 @@ def _merge_yaml(ret, data):
         if topkey not in ret['stat']:
             ret['stat'][topkey] = {}
         ret['stat'][topkey].update(data['stat'][topkey])
-    return ret
-
-
-def _get_yaml(dirname):
-    '''
-    Iterate over the current directory for all yaml files, read them in,
-    merge them, and return the __data__
-    '''
-    ret = {}
-    try:
-        for yamlpath in os.listdir(dirname):
-            if yamlpath.endswith('.yaml') or yamlpath.endswith('.yml'):
-                with open(os.path.join(dirname, yamlpath)) as fh_:
-                    data = yaml.safe_load(fh_)
-                _merge_yaml(ret, data)
-    except:
-        return {}
     return ret
 
 


### PR DESCRIPTION
Change hubble.py to load yaml in addition to python files.

Now audits are targeted by yaml files, rather than python files. All python audit modules must take an additional argument (data_list) which is a list of data loaded from those yaml files. An audit module must only run if it finds its own data in that list.

Also updated pkgng_audit.py to queue off of yaml, and added sample yaml for the purpose.

Fixes #68 
