### PR TITLE
Fix yaml collisions (#87) and fixup #90

### DIFF
--- a/_modules/hubble.py
+++ b/_modules/hubble.py
@@ -90,12 +90,8 @@ def audit(configs='',
         configs = configs.split(',')
 
     # Convert config list to paths, with leading slashes
-    if salt.utils.is_windows():
-        configs = [os.path.join('\\', os.path.join(*(con.split('.yaml')[0]).split('.')))
-                   for con in configs]
-    else:
-        configs = [os.path.join('/', os.path.join(*(con.split('.yaml')[0]).split('.')))
-                   for con in configs]
+    configs = [os.path.join(os.path.sep, os.path.join(*(con.split('.yaml')[0]).split('.')))
+               for con in configs]
 
     results = {'Success': [], 'Failure': []}
 

--- a/hubblestack_nova/pkgng_audit.py
+++ b/hubblestack_nova/pkgng_audit.py
@@ -31,6 +31,9 @@ def audit(data_list, tags, verbose=False):
             __tags__ = ['pkgng_audit']
             break
 
+    log.trace('pkgng audit __tags__:')
+    log.trace(__tags__)
+
     if not __tags__:
         # No yaml data found, don't do any work
         return ret


### PR DESCRIPTION
Fixes #87 
Refs #90 

Basically I now compile the data internally as a list for each check so that conflicting audit IDs don't overwrite each other when compiled from multiple yaml files into a single data structure.

Also edited #90 to use `os.path.sep`.
