### PR TITLE
Topfile support

### DIFF
--- a/_modules/hubble.py
+++ b/_modules/hubble.py
@@ -394,6 +394,33 @@ def _calculate_compliance(results):
     return None
 
 
+def _get_top_data(topfile):
+    '''
+    Helper method to retrieve and parse the nova topfile
+    '''
+    topfile = os.path.join(_hubble_dir(), topfile)
+
+    try:
+        with open(topfile) as handle:
+            topdata = yaml.safe_load(handle)
+    except Exception as e:
+        raise CommandExecutionError('Could not load topfile: {0}'.format(e))
+
+    if not isinstance(topdata, dict) or 'nova' not in topdata or \
+            not(isinstance(topdata['nova'], dict)):
+        raise CommandExecutionError('Nova topfile not formatted correctly')
+
+    topdata = topdata['nova']
+
+    ret = []
+
+    for match, data in topdata.iteritems():
+        if __salt__['match.compound'](match):
+            ret.extend(data)
+
+    return ret
+
+
 class NovaLazyLoader(LazyLoader):
     '''
     Leverage the SaltStack LazyLoader so we don't have to reimplement

--- a/_modules/hubble.py
+++ b/_modules/hubble.py
@@ -101,7 +101,7 @@ def audit(configs='',
     configs = [os.path.join(os.path.sep, os.path.join(*(con.split('.yaml')[0]).split('.')))
                for con in configs]
 
-    results = {'Success': [], 'Failure': [], 'Controlled': []}
+    results = {}
 
     # Compile a list of audit data sets which we need to run
     to_run = set()
@@ -140,10 +140,11 @@ def audit(configs='',
                                           'data': ret}
                 continue
 
-        # Compile the results
-        results['Success'].extend(ret.get('Success', []))
-        results['Failure'].extend(ret.get('Failure', []))
-        results['Controlled'].extend(ret.get('Controlled', []))
+        # Merge in the results
+        for key, val in ret:
+            if key not in results:
+                results[key] = []
+            results[key].extend(val)
 
     if show_compliance:
         compliance = _calculate_compliance(results)
@@ -380,9 +381,13 @@ def _calculate_compliance(results):
     '''
     Calculate compliance numbers given the results of audits
     '''
-    total_audits = len(results['Success']) + len(results['Failure'])
+    success = len(results.get('Success', []))
+    failure = len(results.get('Failure', []))
+    control = len(results.get('Controlled', []))
+    total_audits = success + failure + control
+
     if total_audits:
-        compliance = float(len(results['Success']))/total_audits
+        compliance = float(success + control)/total_audits
         compliance = int(compliance * 100)
         compliance = '{0}%'.format(compliance)
         return compliance

--- a/_modules/hubble.py
+++ b/_modules/hubble.py
@@ -141,7 +141,7 @@ def audit(configs='',
                 continue
 
         # Merge in the results
-        for key, val in ret:
+        for key, val in ret.iteritems():
             if key not in results:
                 results[key] = []
             results[key].extend(val)
@@ -249,7 +249,7 @@ def top(topfile='top.nova',
                 data_by_tag['*'] = []
             data_by_tag['*'].append(data)
         elif isinstance(data, dict):
-            for key, tag in data:
+            for key, tag in data.iteritems():
                 if tag not in data_by_tag:
                     data_by_tag[tag] = []
                 data_by_tag[tag].append(key)
@@ -261,15 +261,15 @@ def top(topfile='top.nova',
             return results
 
     # Run the audits
-    for tag, data in data_by_tag:
-        ret = audit(configs=configs,
+    for tag, data in data_by_tag.iteritems():
+        ret = audit(configs=data,
                     tags=tag,
                     verbose=verbose,
                     show_success=True,
                     show_compliance=False)
 
         # Merge in the results
-        for key, val in ret:
+        for key, val in ret.iteritems():
             if key not in results:
                 results[key] = []
             results[key].extend(val)

--- a/_modules/hubble.py
+++ b/_modules/hubble.py
@@ -85,7 +85,9 @@ def audit(configs=None,
         salt '*' hubble.audit foo,bar.baz verbose=True
     '''
     if configs is None:
-        return top()
+        return top(verbose=verbose,
+                   show_success=show_success,
+                   show_compliance=show_compliance)
 
     if __salt__['config.get']('hubblestack.nova.autoload', True):
         load()


### PR DESCRIPTION
Fixes #69 

Changes:
1. `hubble.audit` with no configs argument now calls `hubble.top`
2. Topfiles are supported, including support for per-yaml-file tag filtering
3. Compliance has been moved out into its own function
4. Return structure much more dynamic, no return key is required. Only show success/failure/control if the underlying audit modules return them
