### PR TITLE
Adding reason for failing stats

### DIFF
--- a/hubblestack_nova/stat.py
+++ b/hubblestack_nova/stat.py
@@ -95,19 +95,23 @@ def audit(data_list, tags, verbose=False):
                     continue
 
                 passed = True
-                reason_dict = {}
+                diff = {}
                 for e in expected.keys():
                     r = salt_ret[e]
                     if e == 'mode' and r != '0':
                         r = r[1:]
                     if str(expected[e]) != str(r):
                         passed = False
-                        reason = { 'expected': str(expected[e]),
-                                   'current': str(r) }
-                        reason_dict[e] = reason
+                        if e not in ['group', 'user']:
+                            diff[e] = str(r)
 
-                if reason_dict:
-                    tag_data['reason'] = reason_dict
+                if diff:
+                    expected_str = ''
+                    found_str = ''
+                    for d in diff:
+                        expected_str = '{0} {1} {2} '.format(expected_str, d, expected[d])
+                        found_str = '{0} {1} {2} '.format(found_str, d, diff[d])
+                    tag_data['reason'] = 'expected: {0} / found: {1}'.format(expected_str, found_str)
 
                 if passed:
                     ret['Success'].append(tag_data)

--- a/hubblestack_nova/stat.py
+++ b/hubblestack_nova/stat.py
@@ -111,7 +111,7 @@ def audit(data_list, tags, verbose=False):
                     for d in diff:
                         expected_str = '{0} {1} {2} '.format(expected_str, d, expected[d])
                         found_str = '{0} {1} {2} '.format(found_str, d, diff[d])
-                    tag_data['reason'] = 'expected: {0} / found: {1}'.format(expected_str, found_str)
+                    tag_data['reason'] = 'expected {0} / found {1}'.format(expected_str, found_str)
 
                 if passed:
                     ret['Success'].append(tag_data)

--- a/hubblestack_nova/stat.py
+++ b/hubblestack_nova/stat.py
@@ -95,23 +95,19 @@ def audit(data_list, tags, verbose=False):
                     continue
 
                 passed = True
-                diff = {}
+                reason_dict = {}
                 for e in expected.keys():
                     r = salt_ret[e]
                     if e == 'mode' and r != '0':
                         r = r[1:]
                     if str(expected[e]) != str(r):
                         passed = False
-                        if e not in ['group', 'user']:
-                            diff[e] = str(r)
+                        reason = { 'expected': str(expected[e]),
+                                   'current': str(r) }
+                        reason_dict[e] = reason
 
-                if diff:
-                    expected_str = ''
-                    found_str = ''
-                    for d in diff:
-                        expected_str = '{0} {1} {2} '.format(expected_str, d, expected[d])
-                        found_str = '{0} {1} {2} '.format(found_str, d, diff[d])
-                    tag_data['reason'] = 'expected {0} / found {1}'.format(expected_str, found_str)
+                if reason_dict:
+                    tag_data['reason'] = reason_dict
 
                 if passed:
                     ret['Success'].append(tag_data)

--- a/hubblestack_nova/stat.py
+++ b/hubblestack_nova/stat.py
@@ -95,12 +95,19 @@ def audit(data_list, tags, verbose=False):
                     continue
 
                 passed = True
+                reason_dict = {}
                 for e in expected.keys():
                     r = salt_ret[e]
                     if e == 'mode' and r != '0':
                         r = r[1:]
                     if str(expected[e]) != str(r):
                         passed = False
+                        reason = { 'expected': str(expected[e]),
+                                   'current': str(r) }
+                        reason_dict[e] = reason
+
+                if reason_dict:
+                    tag_data['reason'] = reason_dict
 
                 if passed:
                     ret['Success'].append(tag_data)


### PR DESCRIPTION
The output looks like this:

```
local:
    ----------
    Compliance:
        78%
    Failure:
        |_
          ----------
          description:
              /etc/cron.d must be owned by root and must have permissions 700
          gid:
              0
          group:
              root
          mode:
              700
          module:
              stat
          name:
              /etc/cron.d
          reason:
              ----------
              mode:
                  ----------
                  current:
                      755
                  expected:
                      700
          tag:
              CIS-6.1.9
          uid:
              0
          user:
              root
```
