### PR TITLE
grep.py: Add support for grep args and regex on match_output

### DIFF
--- a/hubblestack_nova/modules/grep.py
+++ b/hubblestack_nova/modules/grep.py
@@ -27,6 +27,10 @@ grep:
               tag: 'CIS-1.1.1'  # audit tag
               pattern: '/tmp'  # grep pattern
               match_output: 'nodev'  # string to check for in output of grep command (optional)
+              grep_args:  # extra args to grep
+                - '-E'
+                - '-i'
+                - '-B2'
         '*':  # wildcard, will be run if no direct osfinger match
           - '/etc/fstab':
               tag: 'CIS-1.1.1'
@@ -90,9 +94,15 @@ def audit(data_list, tags, verbose=False):
                     ret['Failure'].append(tag_data)
                     continue
 
+                grep_args = tag_data.get('grep_args', [])
+                if isinstance(grep_args, str):
+                    grep_args = [grep_args]
+
                 # Blacklisted packages (must not be installed)
                 if audittype == 'blacklist':
-                    grep_ret = __salt__['file.grep'](name, tag_data['pattern']).get('stdout')
+                    grep_ret = __salt__['file.grep'](name,
+                                                     tag_data['pattern'],
+                                                     *grep_args).get('stdout')
 
                     found = False
                     if grep_ret:
@@ -107,7 +117,9 @@ def audit(data_list, tags, verbose=False):
 
                 # Whitelisted packages (must be installed)
                 elif audittype == 'whitelist':
-                    grep_ret = __salt__['file.grep'](name, tag_data['pattern']).get('stdout')
+                    grep_ret = __salt__['file.grep'](name,
+                                                     tag_data['pattern'],
+                                                     *grep_args).get('stdout')
 
                     found = False
                     if grep_ret:


### PR DESCRIPTION
Fixes #128 
Fixes #55 

Adds support for two new optional pieces of tag data for grep audits:
- `match_output_regex`: set to False by default. If set to True, `re` will be used to evaluate matches on the output
- `grep_args`: list of args to pass to the main grep command
