### PR TITLE
Add osfinger globbing and list support

### DIFF
--- a/hubblestack_nova/modules/grep.py
+++ b/hubblestack_nova/modules/grep.py
@@ -205,7 +205,20 @@ def _get_tags(data):
                 # grep:blacklist:0:telnet
                 tags_dict = audit_data.get('data', {})
                 # grep:blacklist:0:telnet:data
-                tags = tags_dict.get(distro, tags_dict.get('*', []))
+                tags = None
+                for osfinger in tags_dict:
+                    if osfinger == '*':
+                        continue
+                    osfinger_list = osfinger.split(',')
+                    for osfinger_glob in osfinger_list:
+                        if fnmatch.fnmatch(distro, osfinger_glob):
+                            tags = tags_dict.get(osfinger)
+                            break
+                    if tags is not None:
+                        break
+                # If we didn't find a match, check for a '*'
+                if tags is None:
+                    tags = tags_dict.get('*', [])
                 # grep:blacklist:0:telnet:data:Debian-8
                 if isinstance(tags, dict):
                     # malformed yaml, convert to list of dicts

--- a/hubblestack_nova/modules/grep.py
+++ b/hubblestack_nova/modules/grep.py
@@ -209,7 +209,7 @@ def _get_tags(data):
                 for osfinger in tags_dict:
                     if osfinger == '*':
                         continue
-                    osfinger_list = osfinger.split(',')
+                    osfinger_list = [finger.strip() for finger in osfinger.split(',')]
                     for osfinger_glob in osfinger_list:
                         if fnmatch.fnmatch(distro, osfinger_glob):
                             tags = tags_dict.get(osfinger)

--- a/hubblestack_nova/modules/pkg.py
+++ b/hubblestack_nova/modules/pkg.py
@@ -233,7 +233,20 @@ def _get_tags(data):
                 # pkg:blacklist:0:telnet
                 tags_dict = audit_data.get('data', {})
                 # pkg:blacklist:0:telnet:data
-                tags = tags_dict.get(distro, tags_dict.get('*', []))
+                tags = None
+                for osfinger in tags_dict:
+                    if osfinger == '*':
+                        continue
+                    osfinger_list = osfinger.split(',')
+                    for osfinger_glob in osfinger_list:
+                        if fnmatch.fnmatch(distro, osfinger_glob):
+                            tags = tags_dict.get(osfinger)
+                            break
+                    if tags is not None:
+                        break
+                # If we didn't find a match, check for a '*'
+                if tags is None:
+                    tags = tags_dict.get('*', [])
                 # pkg:blacklist:0:telnet:data:Debian-8
                 if isinstance(tags, dict):
                     # malformed yaml, convert to list of dicts

--- a/hubblestack_nova/modules/pkg.py
+++ b/hubblestack_nova/modules/pkg.py
@@ -237,7 +237,7 @@ def _get_tags(data):
                 for osfinger in tags_dict:
                     if osfinger == '*':
                         continue
-                    osfinger_list = osfinger.split(',')
+                    osfinger_list = [finger.strip() for finger in osfinger.split(',')]
                     for osfinger_glob in osfinger_list:
                         if fnmatch.fnmatch(distro, osfinger_glob):
                             tags = tags_dict.get(osfinger)

--- a/hubblestack_nova/modules/service.py
+++ b/hubblestack_nova/modules/service.py
@@ -188,7 +188,7 @@ def _get_tags(data):
                 for osfinger in tags_dict:
                     if osfinger == '*':
                         continue
-                    osfinger_list = osfinger.split(',')
+                    osfinger_list = [finger.strip() for finger in osfinger.split(',')]
                     for osfinger_glob in osfinger_list:
                         if fnmatch.fnmatch(distro, osfinger_glob):
                             tags = tags_dict.get(osfinger)

--- a/hubblestack_nova/modules/service.py
+++ b/hubblestack_nova/modules/service.py
@@ -184,7 +184,20 @@ def _get_tags(data):
                 # service:blacklist:0:telnet
                 tags_dict = audit_data.get('data', {})
                 # service:blacklist:0:telnet:data
-                tags = tags_dict.get(distro, tags_dict.get('*', []))
+                tags = None
+                for osfinger in tags_dict:
+                    if osfinger == '*':
+                        continue
+                    osfinger_list = osfinger.split(',')
+                    for osfinger_glob in osfinger_list:
+                        if fnmatch.fnmatch(distro, osfinger_glob):
+                            tags = tags_dict.get(osfinger)
+                            break
+                    if tags is not None:
+                        break
+                # If we didn't find a match, check for a '*'
+                if tags is None:
+                    tags = tags_dict.get('*', [])
                 # service:blacklist:0:telnet:data:Debian-8
                 if isinstance(tags, dict):
                     # malformed yaml, convert to list of dicts

--- a/hubblestack_nova/modules/stat.py
+++ b/hubblestack_nova/modules/stat.py
@@ -174,7 +174,20 @@ def _get_tags(data):
     for audit_dict in data.get('stat', []):
         for audit_id, audit_data in audit_dict.iteritems():
             tags_dict = audit_data.get('data', {})
-            tags = tags_dict.get(distro, [])
+            tags = None
+            for osfinger in tags_dict:
+                if osfinger == '*':
+                    continue
+                osfinger_list = osfinger.split(',')
+                for osfinger_glob in osfinger_list:
+                    if fnmatch.fnmatch(distro, osfinger_glob):
+                        tags = tags_dict.get(osfinger)
+                        break
+                if tags is not None:
+                    break
+            # If we didn't find a match, check for a '*'
+            if tags is None:
+                tags = tags_dict.get('*', [])
             if isinstance(tags, dict):
                 # malformed yaml, convert to list of dicts
                 tmp = []

--- a/hubblestack_nova/modules/stat.py
+++ b/hubblestack_nova/modules/stat.py
@@ -178,7 +178,7 @@ def _get_tags(data):
             for osfinger in tags_dict:
                 if osfinger == '*':
                     continue
-                osfinger_list = osfinger.split(',')
+                osfinger_list = [finger.strip() for finger in osfinger.split(',')]
                 for osfinger_glob in osfinger_list:
                     if fnmatch.fnmatch(distro, osfinger_glob):
                         tags = tags_dict.get(osfinger)

--- a/hubblestack_nova/modules/sysctl.py
+++ b/hubblestack_nova/modules/sysctl.py
@@ -156,7 +156,7 @@ def _get_tags(data):
             for osfinger in tags_dict:
                 if osfinger == '*':
                     continue
-                osfinger_list = osfinger.split(',')
+                osfinger_list = [finger.strip() for finger in osfinger.split(',')]
                 for osfinger_glob in osfinger_list:
                     if fnmatch.fnmatch(distro, osfinger_glob):
                         tags = tags_dict.get(osfinger)

--- a/hubblestack_nova/modules/sysctl.py
+++ b/hubblestack_nova/modules/sysctl.py
@@ -152,7 +152,20 @@ def _get_tags(data):
     for audit_dict in data.get('sysctl', []):
         for audit_id, audit_data in audit_dict.iteritems():
             tags_dict = audit_data.get('data', {})
-            tags = tags_dict.get(distro, [])
+            tags = None
+            for osfinger in tags_dict:
+                if osfinger == '*':
+                    continue
+                osfinger_list = osfinger.split(',')
+                for osfinger_glob in osfinger_list:
+                    if fnmatch.fnmatch(distro, osfinger_glob):
+                        tags = tags_dict.get(osfinger)
+                        break
+                if tags is not None:
+                    break
+            # If we didn't find a match, check for a '*'
+            if tags is None:
+                tags = tags_dict.get('*', [])
             if isinstance(tags, dict):
                 # malformed yaml, convert to list of dicts
                 tmp = []

--- a/hubblestack_nova/modules/win_regedit.py
+++ b/hubblestack_nova/modules/win_regedit.py
@@ -176,7 +176,20 @@ def _get_tags(data):
                 # regedit:whitelist:PasswordComplexity
                 tags_dict = audit_data.get('data', {})
                 # regedit:whitelist:PasswordComplexity:data
-                tags = tags_dict.get(distro, tags_dict.get('*', []))
+                tags = None
+                for osfinger in tags_dict:
+                    if osfinger == '*':
+                        continue
+                    osfinger_list = osfinger.split(',')
+                    for osfinger_glob in osfinger_list:
+                        if fnmatch.fnmatch(distro, osfinger_glob):
+                            tags = tags_dict.get(osfinger)
+                            break
+                    if tags is not None:
+                        break
+                # If we didn't find a match, check for a '*'
+                if tags is None:
+                    tags = tags_dict.get('*', [])
                 # regedit:whitelist:PasswordComplexity:data:Debian-8
                 if isinstance(tags, dict):
                     # malformed yaml, convert to list of dicts

--- a/hubblestack_nova/modules/win_regedit.py
+++ b/hubblestack_nova/modules/win_regedit.py
@@ -180,7 +180,7 @@ def _get_tags(data):
                 for osfinger in tags_dict:
                     if osfinger == '*':
                         continue
-                    osfinger_list = osfinger.split(',')
+                    osfinger_list = [finger.strip() for finger in osfinger.split(',')]
                     for osfinger_glob in osfinger_list:
                         if fnmatch.fnmatch(distro, osfinger_glob):
                             tags = tags_dict.get(osfinger)

--- a/hubblestack_nova/modules/win_secedit.py
+++ b/hubblestack_nova/modules/win_secedit.py
@@ -201,7 +201,20 @@ def _get_tags(data):
                 # secedit:whitelist:PasswordComplexity
                 tags_dict = audit_data.get('data', {})
                 # secedit:whitelist:PasswordComplexity:data
-                tags = tags_dict.get(distro, tags_dict.get('*', []))
+                tags = None
+                for osfinger in tags_dict:
+                    if osfinger == '*':
+                        continue
+                    osfinger_list = osfinger.split(',')
+                    for osfinger_glob in osfinger_list:
+                        if fnmatch.fnmatch(distro, osfinger_glob):
+                            tags = tags_dict.get(osfinger)
+                            break
+                    if tags is not None:
+                        break
+                # If we didn't find a match, check for a '*'
+                if tags is None:
+                    tags = tags_dict.get('*', [])
                 # secedit:whitelist:PasswordComplexity:data:Debian-8
                 if isinstance(tags, dict):
                     # malformed yaml, convert to list of dicts

--- a/hubblestack_nova/modules/win_secedit.py
+++ b/hubblestack_nova/modules/win_secedit.py
@@ -205,7 +205,7 @@ def _get_tags(data):
                 for osfinger in tags_dict:
                     if osfinger == '*':
                         continue
-                    osfinger_list = osfinger.split(',')
+                    osfinger_list = [finger.strip() for finger in osfinger.split(',')]
                     for osfinger_glob in osfinger_list:
                         if fnmatch.fnmatch(distro, osfinger_glob):
                             tags = tags_dict.get(osfinger)


### PR DESCRIPTION
Now supports comma-separated lists, and globbing for osfinger/osfullname lines in yaml

Fixes #67 
