### PR TITLE
Add show_profile argument

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -244,14 +244,17 @@ include full documentation
         return True
 
 
-    def audit(data_list, tag, verbose=False):
+    def audit(data_list, tag, verbose=False, show_profile=False):
         __tags__ = []
-        for data in data_list:
+        for profile, data in data_list:
             # This is where you process the dictionaries passed in by hubble.py,
             # searching for data pertaining to this audit module. Modules which
             # require no data should use yaml which is empty except for a
             # top-level key, and should only do work if the top-level key is
             # found in the data
+
+            # if show_profile is True, then we need to also inject the profile
+            # in the data for each check so that it appears in verbose output
             pass
 
         ret = {'Success': [], 'Failure': []}
@@ -267,20 +270,23 @@ All Nova plugins require a ``__virtual__()`` function to determine module
 compatibility, and an ``audit()`` function to perform the actual audit
 functionality
 
-The ``audit()`` function must take three arguments, ``data_list``, ``tag`` and
-``verbose``. The ``data_list`` argument is a list of dictionaries passed in by
+The ``audit()`` function must take four arguments, ``data_list``, ``tag``,
+``verbose``, and ``show_profile``. The ``data_list`` argument is a list of dictionaries passed in by
 ``hubble.py``. ``hubble.py`` gets this data from loading the specified yaml for
 the audit run. Your audit module should only run if it finds its own data in
 this list. The ``tag`` argument is a glob expression for which tags the audit
 function should run. It is the job of the audit module to compare the ``tag``
 glob with all tags supported by this module and only run the audits which
 match. The ``verbose`` argument defines whether additional information should
-be returned for audits, such as description and remediation instructions.
+be returned for audits, such as description and remediation instructions. The
+``show_profile`` argument tells whether the profile should be injected into
+the verbose data for each check.
 
-The return value should be a dictionary, with two keys, "Success" and
-"Failure".  The values for these keys should be a list of tags as strings, or a
-list of dictionaries containing tags and other information for the audit (in
-the case of ``verbose``).
+The return value should be a dictionary, with optional keys "Success",
+"Failure", and "Controlled". The values for these keys should be a list of
+one-key dictionaries in the form of ``{<tag>: <string_description>}``, or a
+list of one-key dictionaries in the form of ``{<tag>: <data_dict>}`` (in the
+case of ``verbose``).
 
 Contribute
 ==========

--- a/hubblestack_nova/cis/centos-7-level-1-scored-v2.1.0.yaml
+++ b/hubblestack_nova/cis/centos-7-level-1-scored-v2.1.0.yaml
@@ -437,10 +437,8 @@ grep:
             pattern: PASS_WARN_DAYS
             tag: CIS-5.4.1.3
       description: Ensure password expiration warning days is 7 or more
-    passwd_inactiive:
-      data:
     passwd_inactive:
-      data: 
+      data:
         CentOS Linux-7:
         - /etc/default/useradd:
             pattern: INACTIVE=30

--- a/hubblestack_nova/cis/centos-7-level-1-scored-v2.yaml
+++ b/hubblestack_nova/cis/centos-7-level-1-scored-v2.yaml
@@ -437,10 +437,8 @@ grep:
             pattern: PASS_WARN_DAYS
             tag: CIS-5.4.1.3
       description: Set Password Expiring Warning Days (Scored)
-    passwd_inactiive:
-      data:
     passwd_inactive:
-      data: 
+      data:
         CentOS Linux-7:
         - /etc/default/useradd:
             pattern: INACTIVE=30

--- a/hubblestack_nova/cis/rhels-7-level-1-scored-v1.yaml
+++ b/hubblestack_nova/cis/rhels-7-level-1-scored-v1.yaml
@@ -437,10 +437,8 @@ grep:
             pattern: PASS_WARN_DAYS
             tag: CIS-5.4.1.3
       description: Set Password Expiring Warning Days (Scored)
-    passwd_inactiive:
-      data:
     passwd_inactive:
-      data: 
+      data:
         Red Hat Enterprise Linux Server-7:
         - /etc/default/useradd:
             pattern: INACTIVE=30

--- a/hubblestack_nova/cis/rhels-7-level-1-scored-v2.1.0.yaml
+++ b/hubblestack_nova/cis/rhels-7-level-1-scored-v2.1.0.yaml
@@ -437,10 +437,8 @@ grep:
             pattern: PASS_WARN_DAYS
             tag: CIS-5.4.1.3
       description: Ensure password expiration warning days is 7 or more
-    passwd_inactiive:
-      data:
     passwd_inactive:
-      data: 
+      data:
         Red Hat Enterprise Linux Server-7:
         - /etc/default/useradd:
             pattern: INACTIVE=30

--- a/hubblestack_nova/cis/rhelw-7-level-1-scored-v1.yaml
+++ b/hubblestack_nova/cis/rhelw-7-level-1-scored-v1.yaml
@@ -427,10 +427,8 @@ grep:
             pattern: PASS_WARN_DAYS
             tag: CIS-5.4.1.3
       description: Set Password Expiring Warning Days (Scored)
-    passwd_inactiive:
-      data:
     passwd_inactive:
-      data: 
+      data:
         Red Hat Enterprise Linux Workstation-7:
         - /etc/default/useradd:
             pattern: INACTIVE=30

--- a/hubblestack_nova/cis/rhelw-7-level-1-scored-v2.1.0.yaml
+++ b/hubblestack_nova/cis/rhelw-7-level-1-scored-v2.1.0.yaml
@@ -427,10 +427,8 @@ grep:
             pattern: PASS_WARN_DAYS
             tag: CIS-5.4.1.3
       description: Ensure password expiration warning days is 7 or more
-    passwd_inactiive:
-      data:
     passwd_inactive:
-      data: 
+      data:
         Red Hat Enterprise Linux Workstation-7:
         - /etc/default/useradd:
             pattern: INACTIVE=30

--- a/hubblestack_nova/modules/command.py
+++ b/hubblestack_nova/modules/command.py
@@ -156,11 +156,12 @@ def audit(data_list, tags, verbose=False, show_profile=False):
                     else:
                         ret['Failure'].append(tag_data)
 
-    if not verbose:
-        failure = []
-        success = []
-        controlled = []
+    failure = []
+    success = []
+    controlled = []
 
+    if not verbose:
+        # Pull out just the tag and description
         tags_descriptions = set()
 
         for tag_data in ret['Failure']:
@@ -191,9 +192,23 @@ def audit(data_list, tags, verbose=False, show_profile=False):
                 controlled.append({tag: tag_dict})
                 control_reasons.add((tag, description, control_reason))
 
-        ret['Controlled'] = controlled
-        ret['Success'] = success
-        ret['Failure'] = failure
+    else:
+        # Format verbose output as single-key dictionaries with tag as key
+        for tag_data in ret['Failure']:
+            tag = tag_data['tag']
+            failure.append({tag: tag_data})
+
+        for tag_data in ret['Success']:
+            tag = tag_data['tag']
+            success.append({tag: tag_data})
+
+        for tag_data in ret['Controlled']:
+            tag = tag_data['tag']
+            controlled.append({tag: tag_data})
+
+    ret['Controlled'] = controlled
+    ret['Success'] = success
+    ret['Failure'] = failure
 
     if not ret['Controlled']:
         ret.pop('Controlled')
@@ -209,8 +224,8 @@ def _merge_yaml(ret, data, profile=None):
         ret['command'] = []
     if 'command' in data:
         for key, val in data['command'].iteritems():
-            if profile and 'data' in val:
-                val['data']['nova_profile'] = profile
+            if profile and isinstance(val, dict):
+                val['nova_profile'] = profile
             ret['command'].append({key: val})
     return ret
 

--- a/hubblestack_nova/modules/command.py
+++ b/hubblestack_nova/modules/command.py
@@ -82,13 +82,16 @@ def __virtual__():
     return True
 
 
-def audit(data_list, tags, verbose=False):
+def audit(data_list, tags, verbose=False, show_profile=False):
     '''
     Run the command audits contained in the data_list
     '''
     __data__ = {}
-    for data in data_list:
-        _merge_yaml(__data__, data)
+    for profile, data in data_list:
+        if show_profile:
+            _merge_yaml(__data__, data, profile)
+        else:
+            _merge_yaml(__data__, data)
     __tags__ = _get_tags(__data__)
 
     log.trace('command audit __data__:')
@@ -198,7 +201,7 @@ def audit(data_list, tags, verbose=False):
     return ret
 
 
-def _merge_yaml(ret, data):
+def _merge_yaml(ret, data, profile=None):
     '''
     Merge two yaml dicts together at the command level
     '''
@@ -206,6 +209,8 @@ def _merge_yaml(ret, data):
         ret['command'] = []
     if 'command' in data:
         for key, val in data['command'].iteritems():
+            if profile and 'data' in val:
+                val['data']['nova_profile'] = profile
             ret['command'].append({key: val})
     return ret
 

--- a/hubblestack_nova/modules/cve_scan.py
+++ b/hubblestack_nova/modules/cve_scan.py
@@ -21,7 +21,7 @@ def __virtual__():
     return False, 'This module requires Linux and the oscap binary'
 
 
-def audit(data_list, tags, verbose=False):
+def audit(data_list, tags, verbose=False, show_profile=False):
     '''
     Run the network.netstat command
     '''

--- a/hubblestack_nova/modules/firewall.py
+++ b/hubblestack_nova/modules/firewall.py
@@ -99,10 +99,13 @@ def __virtual__():
     return True
 
 
-def audit(data_list, tags, verbose=False):
+def audit(data_list, tags, verbose=False, show_profile=False):
     __data__ = {}
-    for data in data_list:
-        _merge_yaml(__data__, data)
+    for profile, data in data_list:
+        if show_profile:
+            _merge_yaml(__data__, data, profile)
+        else:
+            _merge_yaml(__data__, data)
     __tags__ = _get_tags(__data__)
 
     log.trace('service audit __data__:')
@@ -204,7 +207,7 @@ def audit(data_list, tags, verbose=False):
     return ret
 
 
-def _merge_yaml(ret, data):
+def _merge_yaml(ret, data, profile=None):
     '''
     Merge two yaml dicts together at the pkg:blacklist and pkg:whitelist level
     '''
@@ -215,6 +218,8 @@ def _merge_yaml(ret, data):
             if topkey not in ret['firewall']:
                 ret['firewall'][topkey] = []
             for key, val in data['firewall'][topkey].iteritems():
+                if profile and 'data' in val:
+                    val['data']['nova_profile'] = profile
                 ret['firewall'][topkey].append({key: val})
     return ret
 

--- a/hubblestack_nova/modules/firewall.py
+++ b/hubblestack_nova/modules/firewall.py
@@ -162,11 +162,12 @@ def audit(data_list, tags, verbose=False, show_profile=False):
                 else:
                     ret['Failure'].append(tag_data)
 
-    if not verbose:
-        failure = []
-        success = []
-        controlled = []
+    failure = []
+    success = []
+    controlled = []
 
+    if not verbose:
+        # Pull out just the tag and description
         tags_descriptions = set()
 
         for tag_data in ret['Failure']:
@@ -197,9 +198,23 @@ def audit(data_list, tags, verbose=False, show_profile=False):
                 controlled.append({tag: tag_dict})
                 control_reasons.add((tag, description, control_reason))
 
-        ret['Controlled'] = controlled
-        ret['Success'] = success
-        ret['Failure'] = failure
+    else:
+        # Format verbose output as single-key dictionaries with tag as key
+        for tag_data in ret['Failure']:
+            tag = tag_data['tag']
+            failure.append({tag: tag_data})
+
+        for tag_data in ret['Success']:
+            tag = tag_data['tag']
+            success.append({tag: tag_data})
+
+        for tag_data in ret['Controlled']:
+            tag = tag_data['tag']
+            controlled.append({tag: tag_data})
+
+    ret['Controlled'] = controlled
+    ret['Success'] = success
+    ret['Failure'] = failure
 
     if not ret['Controlled']:
         ret.pop('Controlled')
@@ -218,8 +233,8 @@ def _merge_yaml(ret, data, profile=None):
             if topkey not in ret['firewall']:
                 ret['firewall'][topkey] = []
             for key, val in data['firewall'][topkey].iteritems():
-                if profile and 'data' in val:
-                    val['data']['nova_profile'] = profile
+                if profile and isinstance(val, dict):
+                    val['nova_profile'] = profile
                 ret['firewall'][topkey].append({key: val})
     return ret
 

--- a/hubblestack_nova/modules/grep.py
+++ b/hubblestack_nova/modules/grep.py
@@ -83,6 +83,7 @@ def audit(data_list, tags, verbose=False, show_profile=False):
             _merge_yaml(__data__, data, profile)
         else:
             _merge_yaml(__data__, data)
+    __tags__ = _get_tags(__data__)
 
     log.trace('grep audit __data__:')
     log.trace(__data__)

--- a/hubblestack_nova/modules/grep.py
+++ b/hubblestack_nova/modules/grep.py
@@ -147,11 +147,12 @@ def audit(data_list, tags, verbose=False, show_profile=False):
                     else:
                         ret['Failure'].append(tag_data)
 
-    if not verbose:
-        failure = []
-        success = []
-        controlled = []
+    failure = []
+    success = []
+    controlled = []
 
+    if not verbose:
+        # Pull out just the tag and description
         tags_descriptions = set()
 
         for tag_data in ret['Failure']:
@@ -182,9 +183,23 @@ def audit(data_list, tags, verbose=False, show_profile=False):
                 controlled.append({tag: tag_dict})
                 control_reasons.add((tag, description, control_reason))
 
-        ret['Controlled'] = controlled
-        ret['Success'] = success
-        ret['Failure'] = failure
+    else:
+        # Format verbose output as single-key dictionaries with tag as key
+        for tag_data in ret['Failure']:
+            tag = tag_data['tag']
+            failure.append({tag: tag_data})
+
+        for tag_data in ret['Success']:
+            tag = tag_data['tag']
+            success.append({tag: tag_data})
+
+        for tag_data in ret['Controlled']:
+            tag = tag_data['tag']
+            controlled.append({tag: tag_data})
+
+    ret['Controlled'] = controlled
+    ret['Success'] = success
+    ret['Failure'] = failure
 
     if not ret['Controlled']:
         ret.pop('Controlled')
@@ -203,8 +218,8 @@ def _merge_yaml(ret, data, profile=None):
             if topkey not in ret['grep']:
                 ret['grep'][topkey] = []
             for key, val in data['grep'][topkey].iteritems():
-                if profile and 'data' in val:
-                    val['data']['nova_profile'] = profile
+                if profile and isinstance(val, dict):
+                    val['nova_profile'] = profile
                 ret['grep'][topkey].append({key: val})
     return ret
 

--- a/hubblestack_nova/modules/grep.py
+++ b/hubblestack_nova/modules/grep.py
@@ -73,14 +73,16 @@ def __virtual__():
     return True
 
 
-def audit(data_list, tags, verbose=False):
+def audit(data_list, tags, verbose=False, show_profile=False):
     '''
     Run the grep audits contained in the YAML files processed by __virtual__
     '''
     __data__ = {}
-    for data in data_list:
-        _merge_yaml(__data__, data)
-    __tags__ = _get_tags(__data__)
+    for profile, data in data_list:
+        if show_profile:
+            _merge_yaml(__data__, data, profile)
+        else:
+            _merge_yaml(__data__, data)
 
     log.trace('grep audit __data__:')
     log.trace(__data__)
@@ -189,7 +191,7 @@ def audit(data_list, tags, verbose=False):
     return ret
 
 
-def _merge_yaml(ret, data):
+def _merge_yaml(ret, data, profile=None):
     '''
     Merge two yaml dicts together at the grep:blacklist and grep:whitelist level
     '''
@@ -200,6 +202,8 @@ def _merge_yaml(ret, data):
             if topkey not in ret['grep']:
                 ret['grep'][topkey] = []
             for key, val in data['grep'][topkey].iteritems():
+                if profile and 'data' in val:
+                    val['data']['nova_profile'] = profile
                 ret['grep'][topkey].append({key: val})
     return ret
 

--- a/hubblestack_nova/modules/netstat.py
+++ b/hubblestack_nova/modules/netstat.py
@@ -80,6 +80,7 @@ def audit(data_list, tags, verbose=False, show_profile=False):
                 failure_data = {address: {'program': address_data['program']}}
                 failure_data[address].update(address_data)
                 failure_data[address]['description'] = address_data['program']
+                failure_data[address]['nova_profile'] = 'netstat'
             ret['Failure'].append(failure_data)
 
     return ret

--- a/hubblestack_nova/modules/netstat.py
+++ b/hubblestack_nova/modules/netstat.py
@@ -36,19 +36,21 @@ def __virtual__():
     return False, 'No network.netstat function found'
 
 
-def audit(data_list, tags, verbose=False):
+def audit(data_list, tags, verbose=False, show_profile=False):
     '''
     Run the network.netstat command
     '''
     ret = {'Success': [], 'Failure': []}
 
     __tags__ = {}
-    for data in data_list:
+    for profile, data in data_list:
         if 'netstat' in data:
             for check, check_args in data['netstat'].iteritems():
                 if 'address' in check_args:
                     tag_args = copy.deepcopy(check_args)
                     tag_args['id'] = check
+                    if show_profile:
+                        tag_args['nova_profile'] = profile
                     if isinstance(check_args['address'], list):
                         for address in check_args['address']:
                             __tags__[address] = tag_args

--- a/hubblestack_nova/modules/openssl.py
+++ b/hubblestack_nova/modules/openssl.py
@@ -99,10 +99,13 @@ def __virtual__():
     return True
 
 
-def audit(data_list, tags, verbose=False):
+def audit(data_list, tags, verbose=False, show_profile=False):
     __data__ = {}
-    for data in data_list:
-        _merge_yaml(__data__, data)
+    for profile, data in data_list:
+        if show_profile:
+            _merge_yaml(__data__, data, profile)
+        else:
+            _merge_yaml(__data__, data)
     __tags__ = _get_tags(__data__)
 
     log.trace('service audit __data__:')
@@ -195,10 +198,12 @@ def audit(data_list, tags, verbose=False):
     return ret
 
 
-def _merge_yaml(ret, data):
+def _merge_yaml(ret, data, profile=None):
     if 'openssl' not in ret:
         ret['openssl'] = []
     for key, val in data.get('openssl', {}).iteritems():
+        if profile and 'data' in val:
+            val['data']['nova_profile'] = profile
         ret['openssl'].append({key: val})
     return ret
 

--- a/hubblestack_nova/modules/openssl.py
+++ b/hubblestack_nova/modules/openssl.py
@@ -153,11 +153,12 @@ def audit(data_list, tags, verbose=False, show_profile=False):
                     tag_data['reason'] = failing_reason
                     ret['Failure'].append(tag_data)
 
-    if not verbose:
-        failure = []
-        success = []
-        controlled = []
+    failure = []
+    success = []
+    controlled = []
 
+    if not verbose:
+        # Pull out just the tag and description
         tags_descriptions = set()
 
         for tag_data in ret['Failure']:
@@ -188,9 +189,23 @@ def audit(data_list, tags, verbose=False, show_profile=False):
                 controlled.append({tag: tag_dict})
                 control_reasons.add((tag, description, control_reason))
 
-        ret['Controlled'] = controlled
-        ret['Success'] = success
-        ret['Failure'] = failure
+    else:
+        # Format verbose output as single-key dictionaries with tag as key
+        for tag_data in ret['Failure']:
+            tag = tag_data['tag']
+            failure.append({tag: tag_data})
+
+        for tag_data in ret['Success']:
+            tag = tag_data['tag']
+            success.append({tag: tag_data})
+
+        for tag_data in ret['Controlled']:
+            tag = tag_data['tag']
+            controlled.append({tag: tag_data})
+
+    ret['Controlled'] = controlled
+    ret['Success'] = success
+    ret['Failure'] = failure
 
     if not ret['Controlled']:
         ret.pop('Controlled')
@@ -202,8 +217,8 @@ def _merge_yaml(ret, data, profile=None):
     if 'openssl' not in ret:
         ret['openssl'] = []
     for key, val in data.get('openssl', {}).iteritems():
-        if profile and 'data' in val:
-            val['data']['nova_profile'] = profile
+        if profile and isinstance(val, dict):
+            val['nova_profile'] = profile
         ret['openssl'].append({key: val})
     return ret
 

--- a/hubblestack_nova/modules/pkg.py
+++ b/hubblestack_nova/modules/pkg.py
@@ -79,13 +79,16 @@ def __virtual__():
     return True
 
 
-def audit(data_list, tags, verbose=False):
+def audit(data_list, tags, verbose=False, show_profile=False):
     '''
     Run the pkg audits contained in the YAML files processed by __virtual__
     '''
     __data__ = {}
-    for data in data_list:
-        _merge_yaml(__data__, data)
+    for profile, data in data_list:
+        if show_profile:
+            _merge_yaml(__data__, data, profile)
+        else:
+            _merge_yaml(__data__, data)
     __tags__ = _get_tags(__data__)
 
     log.trace('pkg audit __data__:')
@@ -199,7 +202,7 @@ def audit(data_list, tags, verbose=False):
     return ret
 
 
-def _merge_yaml(ret, data):
+def _merge_yaml(ret, data, profile=None):
     '''
     Merge two yaml dicts together at the pkg:blacklist and pkg:whitelist level
     '''
@@ -210,6 +213,8 @@ def _merge_yaml(ret, data):
             if topkey not in ret['pkg']:
                 ret['pkg'][topkey] = []
             for key, val in data['pkg'][topkey].iteritems():
+                if profile and 'data' in val:
+                    val['data']['nova_profile'] = profile
                 ret['pkg'][topkey].append({key: val})
     return ret
 

--- a/hubblestack_nova/modules/pkg.py
+++ b/hubblestack_nova/modules/pkg.py
@@ -157,11 +157,12 @@ def audit(data_list, tags, verbose=False, show_profile=False):
                         else:
                             ret['Failure'].append(tag_data)
 
-    if not verbose:
-        failure = []
-        success = []
-        controlled = []
+    failure = []
+    success = []
+    controlled = []
 
+    if not verbose:
+        # Pull out just the tag and description
         tags_descriptions = set()
 
         for tag_data in ret['Failure']:
@@ -192,9 +193,23 @@ def audit(data_list, tags, verbose=False, show_profile=False):
                 controlled.append({tag: tag_dict})
                 control_reasons.add((tag, description, control_reason))
 
-        ret['Controlled'] = controlled
-        ret['Success'] = success
-        ret['Failure'] = failure
+    else:
+        # Format verbose output as single-key dictionaries with tag as key
+        for tag_data in ret['Failure']:
+            tag = tag_data['tag']
+            failure.append({tag: tag_data})
+
+        for tag_data in ret['Success']:
+            tag = tag_data['tag']
+            success.append({tag: tag_data})
+
+        for tag_data in ret['Controlled']:
+            tag = tag_data['tag']
+            controlled.append({tag: tag_data})
+
+    ret['Controlled'] = controlled
+    ret['Success'] = success
+    ret['Failure'] = failure
 
     if not ret['Controlled']:
         ret.pop('Controlled')
@@ -213,8 +228,8 @@ def _merge_yaml(ret, data, profile=None):
             if topkey not in ret['pkg']:
                 ret['pkg'][topkey] = []
             for key, val in data['pkg'][topkey].iteritems():
-                if profile and 'data' in val:
-                    val['data']['nova_profile'] = profile
+                if profile and isinstance(val, dict):
+                    val['nova_profile'] = profile
                 ret['pkg'][topkey].append({key: val})
     return ret
 

--- a/hubblestack_nova/modules/pkgng_audit.py
+++ b/hubblestack_nova/modules/pkgng_audit.py
@@ -20,14 +20,14 @@ def __virtual__():
     return True
 
 
-def audit(data_list, tags, verbose=False):
+def audit(data_list, tags, verbose=False, show_profile=False):
     '''
     Run the pkg.audit command
     '''
     ret = {'Success': [], 'Failure': []}
 
     __tags__ = []
-    for data in data_list:
+    for profile, data in data_list:
         if 'pkgng_audit' in data:
             __tags__ = ['pkgng_audit']
             break
@@ -40,9 +40,14 @@ def audit(data_list, tags, verbose=False):
         return ret
 
     salt_ret = __salt__['pkg.audit']()
+    results = {'result': salt_ret}
+    if show_profile:
+        results['nova_profile'] = profile
+    if not verbose:
+        results = salt_ret
     if '0 problem(s)' not in salt_ret:
-        ret['Failure'].append(salt_ret)
+        ret['Failure'].append(results)
     else:
-        ret['Success'].append(salt_ret)
+        ret['Success'].append(results)
 
     return ret

--- a/hubblestack_nova/modules/pkgng_audit.py
+++ b/hubblestack_nova/modules/pkgng_audit.py
@@ -40,9 +40,9 @@ def audit(data_list, tags, verbose=False, show_profile=False):
         return ret
 
     salt_ret = __salt__['pkg.audit']()
-    results = {'result': salt_ret}
+    results = {'pkgng_audit': {'result': salt_ret}}
     if show_profile:
-        results['nova_profile'] = profile
+        results['pkng_audit']['nova_profile'] = profile
     if not verbose:
         results = salt_ret
     if '0 problem(s)' not in salt_ret:

--- a/hubblestack_nova/modules/service.py
+++ b/hubblestack_nova/modules/service.py
@@ -72,13 +72,16 @@ def __virtual__():
     return True
 
 
-def audit(data_list, tags, verbose=False):
+def audit(data_list, tags, verbose=False, show_profile=False):
     '''
     Run the service audits contained in the YAML files processed by __virtual__
     '''
     __data__ = {}
-    for data in data_list:
-        _merge_yaml(__data__, data)
+    for profile, data in data_list:
+        if show_profile:
+            _merge_yaml(__data__, data, profile)
+        else:
+            _merge_yaml(__data__, data)
     __tags__ = _get_tags(__data__)
 
     log.trace('service audit __data__:')
@@ -155,7 +158,7 @@ def audit(data_list, tags, verbose=False):
     return ret
 
 
-def _merge_yaml(ret, data):
+def _merge_yaml(ret, data, profile=None):
     '''
     Merge two yaml dicts together at the service:blacklist and service:whitelist level
     '''
@@ -166,6 +169,8 @@ def _merge_yaml(ret, data):
             if topkey not in ret['service']:
                 ret['service'][topkey] = []
             for key, val in data['service'][topkey].iteritems():
+                if profile and 'data' in val:
+                    val['data']['nova_profile'] = profile
                 ret['service'][topkey].append({key: val})
     return ret
 

--- a/hubblestack_nova/modules/service.py
+++ b/hubblestack_nova/modules/service.py
@@ -113,11 +113,12 @@ def audit(data_list, tags, verbose=False, show_profile=False):
                     else:
                         ret['Failure'].append(tag_data)
 
-    if not verbose:
-        failure = []
-        success = []
-        controlled = []
+    failure = []
+    success = []
+    controlled = []
 
+    if not verbose:
+        # Pull out just the tag and description
         tags_descriptions = set()
 
         for tag_data in ret['Failure']:
@@ -148,9 +149,23 @@ def audit(data_list, tags, verbose=False, show_profile=False):
                 controlled.append({tag: tag_dict})
                 control_reasons.add((tag, description, control_reason))
 
-        ret['Controlled'] = controlled
-        ret['Success'] = success
-        ret['Failure'] = failure
+    else:
+        # Format verbose output as single-key dictionaries with tag as key
+        for tag_data in ret['Failure']:
+            tag = tag_data['tag']
+            failure.append({tag: tag_data})
+
+        for tag_data in ret['Success']:
+            tag = tag_data['tag']
+            success.append({tag: tag_data})
+
+        for tag_data in ret['Controlled']:
+            tag = tag_data['tag']
+            controlled.append({tag: tag_data})
+
+    ret['Controlled'] = controlled
+    ret['Success'] = success
+    ret['Failure'] = failure
 
     if not ret['Controlled']:
         ret.pop('Controlled')
@@ -169,8 +184,8 @@ def _merge_yaml(ret, data, profile=None):
             if topkey not in ret['service']:
                 ret['service'][topkey] = []
             for key, val in data['service'][topkey].iteritems():
-                if profile and 'data' in val:
-                    val['data']['nova_profile'] = profile
+                if profile and isinstance(val, dict):
+                    val['nova_profile'] = profile
                 ret['service'][topkey].append({key: val})
     return ret
 

--- a/hubblestack_nova/modules/stat.py
+++ b/hubblestack_nova/modules/stat.py
@@ -117,11 +117,12 @@ def audit(data_list, tags, verbose=False, show_profile=False):
                 else:
                     ret['Failure'].append(tag_data)
 
-    if not verbose:
-        failure = []
-        success = []
-        controlled = []
+    failure = []
+    success = []
+    controlled = []
 
+    if not verbose:
+        # Pull out just the tag and description
         tags_descriptions = set()
 
         for tag_data in ret['Failure']:
@@ -152,10 +153,23 @@ def audit(data_list, tags, verbose=False, show_profile=False):
                 controlled.append({tag: tag_dict})
                 control_reasons.add((tag, description, control_reason))
 
+    else:
+        # Format verbose output as single-key dictionaries with tag as key
+        for tag_data in ret['Failure']:
+            tag = tag_data['tag']
+            failure.append({tag: tag_data})
 
-        ret['Controlled'] = controlled
-        ret['Success'] = success
-        ret['Failure'] = failure
+        for tag_data in ret['Success']:
+            tag = tag_data['tag']
+            success.append({tag: tag_data})
+
+        for tag_data in ret['Controlled']:
+            tag = tag_data['tag']
+            controlled.append({tag: tag_data})
+
+    ret['Controlled'] = controlled
+    ret['Success'] = success
+    ret['Failure'] = failure
 
     if not ret['Controlled']:
         ret.pop('Controlled')
@@ -171,8 +185,8 @@ def _merge_yaml(ret, data, profile=None):
     if 'stat' not in ret:
         ret['stat'] = []
     for key, val in data.get('stat', {}).iteritems():
-        if profile and 'data' in val:
-            val['data']['nova_profile'] = profile
+        if profile and isinstance(val, dict):
+            val['nova_profile'] = profile
         ret['stat'].append({key: val})
     return ret
 

--- a/hubblestack_nova/modules/stat.py
+++ b/hubblestack_nova/modules/stat.py
@@ -57,13 +57,16 @@ def __virtual__():
     return True
 
 
-def audit(data_list, tags, verbose=False):
+def audit(data_list, tags, verbose=False, show_profile=False):
     '''
     Run the stat audits contained in the YAML files processed by __virtual__
     '''
     __data__ = {}
-    for data in data_list:
-        _merge_yaml(__data__, data)
+    for profile, data in data_list:
+        if show_profile:
+            _merge_yaml(__data__, data, profile)
+        else:
+            _merge_yaml(__data__, data)
     __tags__ = _get_tags(__data__)
 
     log.trace('service audit __data__:')
@@ -161,13 +164,15 @@ def audit(data_list, tags, verbose=False):
 
 
 
-def _merge_yaml(ret, data):
+def _merge_yaml(ret, data, profile=None):
     '''
     Merge two yaml dicts together
     '''
     if 'stat' not in ret:
         ret['stat'] = []
     for key, val in data.get('stat', {}).iteritems():
+        if profile and 'data' in val:
+            val['data']['nova_profile'] = profile
         ret['stat'].append({key: val})
     return ret
 

--- a/hubblestack_nova/modules/sysctl.py
+++ b/hubblestack_nova/modules/sysctl.py
@@ -90,11 +90,12 @@ def audit(data_list, tags, verbose=False, show_profile=False):
             else:
                 ret['Failure'].append(tag_data)
 
-    if not verbose:
-        failure = []
-        success = []
-        controlled = []
+    failure = []
+    success = []
+    controlled = []
 
+    if not verbose:
+        # Pull out just the tag and description
         tags_descriptions = set()
 
         for tag_data in ret['Failure']:
@@ -125,9 +126,23 @@ def audit(data_list, tags, verbose=False, show_profile=False):
                 controlled.append({tag: tag_dict})
                 control_reasons.add((tag, description, control_reason))
 
-        ret['Controlled'] = controlled
-        ret['Success'] = success
-        ret['Failure'] = failure
+    else:
+        # Format verbose output as single-key dictionaries with tag as key
+        for tag_data in ret['Failure']:
+            tag = tag_data['tag']
+            failure.append({tag: tag_data})
+
+        for tag_data in ret['Success']:
+            tag = tag_data['tag']
+            success.append({tag: tag_data})
+
+        for tag_data in ret['Controlled']:
+            tag = tag_data['tag']
+            controlled.append({tag: tag_data})
+
+    ret['Controlled'] = controlled
+    ret['Success'] = success
+    ret['Failure'] = failure
 
     if not ret['Controlled']:
         ret.pop('Controlled')
@@ -142,8 +157,8 @@ def _merge_yaml(ret, data, profile=None):
     if 'sysctl' not in ret:
         ret['sysctl'] = []
     for key, val in data.get('sysctl', {}).iteritems():
-        if profile and 'data' in val:
-            val['data']['nova_profile'] = profile
+        if profile and isinstance(val, dict):
+            val['nova_profile'] = profile
         ret['sysctl'].append({key: val})
     return ret
 

--- a/hubblestack_nova/modules/sysctl.py
+++ b/hubblestack_nova/modules/sysctl.py
@@ -49,13 +49,16 @@ def __virtual__():
     return True
 
 
-def audit(data_list, tags, verbose=False):
+def audit(data_list, tags, verbose=False, show_profile=False):
     '''
     Run the sysctl audits contained in the YAML files processed by __virtual__
     '''
     __data__ = {}
-    for data in data_list:
-        _merge_yaml(__data__, data)
+    for profile, data in data_list:
+        if show_profile:
+            _merge_yaml(__data__, data, profile)
+        else:
+            _merge_yaml(__data__, data)
     __tags__ = _get_tags(__data__)
 
     log.trace('service audit __data__:')
@@ -132,13 +135,15 @@ def audit(data_list, tags, verbose=False):
     return ret
 
 
-def _merge_yaml(ret, data):
+def _merge_yaml(ret, data, profile=None):
     '''
     Merge two yaml dicts together
     '''
     if 'sysctl' not in ret:
         ret['sysctl'] = []
     for key, val in data.get('sysctl', {}).iteritems():
+        if profile and 'data' in val:
+            val['data']['nova_profile'] = profile
         ret['sysctl'].append({key: val})
     return ret
 

--- a/hubblestack_nova/modules/win_auditpol.py
+++ b/hubblestack_nova/modules/win_auditpol.py
@@ -72,11 +72,12 @@ def audit(data_list, tags, verbose=False, show_profile=False):
                         log.debug('When trying to audit the advanced auditpol section,'
                                   ' the yaml contained incorrect data for the key')
 
-    if not verbose:
-        failure = []
-        success = []
-        controlled = []
+    failure = []
+    success = []
+    controlled = []
 
+    if not verbose:
+        # Pull out just the tag and description
         tags_descriptions = set()
 
         for tag_data in ret['Failure']:
@@ -107,9 +108,23 @@ def audit(data_list, tags, verbose=False, show_profile=False):
                 controlled.append({tag: description})
                 control_reasons.add((tag, description, control_reason))
 
-        ret['Controlled'] = controlled
-        ret['Success'] = success
-        ret['Failure'] = failure
+    else:
+        # Format verbose output as single-key dictionaries with tag as key
+        for tag_data in ret['Failure']:
+            tag = tag_data['tag']
+            failure.append({tag: tag_data})
+
+        for tag_data in ret['Success']:
+            tag = tag_data['tag']
+            success.append({tag: tag_data})
+
+        for tag_data in ret['Controlled']:
+            tag = tag_data['tag']
+            controlled.append({tag: tag_data})
+
+    ret['Controlled'] = controlled
+    ret['Success'] = success
+    ret['Failure'] = failure
 
     if not ret['Controlled']:
         ret.pop('Controlled')
@@ -129,8 +144,8 @@ def _merge_yaml(ret, data, profile=None):
             if topkey not in ret[__virtualname__]:
                 ret[__virtualname__][topkey] = []
             for key, val in data[__virtualname__][topkey].iteritems():
-                if profile and 'data' in val:
-                    val['data']['nova_profile'] = profile
+                if profile and isinstance(val, dict):
+                    val['nova_profile'] = profile
                 ret[__virtualname__][topkey].append({key: val})
     return ret
 

--- a/hubblestack_nova/modules/win_auditpol.py
+++ b/hubblestack_nova/modules/win_auditpol.py
@@ -25,13 +25,16 @@ def __virtual__():
     return True
 
 
-def audit(data_list, tags, verbose=False):
+def audit(data_list, tags, verbose=False, show_profile=False):
     '''Runs auditpol on the local machine and audits the return data
     with the CIS yaml processed by __virtual__'''
     __data__ = {}
     __auditdata__ = _auditpol_import()
-    for data in data_list:
-        _merge_yaml(__data__, data)
+    for profile, data in data_list:
+        if show_profile:
+            _merge_yaml(__data__, data, profile)
+        else:
+            _merge_yaml(__data__, data)
     __tags__ = _get_tags(__data__)
     log.trace('auditpol audit __data__:')
     log.trace(__data__)
@@ -114,7 +117,7 @@ def audit(data_list, tags, verbose=False):
     return ret
 
 
-def _merge_yaml(ret, data):
+def _merge_yaml(ret, data, profile=None):
     '''
     Merge two yaml dicts together at the secedit:blacklist and
     secedit:whitelist level
@@ -126,6 +129,8 @@ def _merge_yaml(ret, data):
             if topkey not in ret[__virtualname__]:
                 ret[__virtualname__][topkey] = []
             for key, val in data[__virtualname__][topkey].iteritems():
+                if profile and 'data' in val:
+                    val['data']['nova_profile'] = profile
                 ret[__virtualname__][topkey].append({key: val})
     return ret
 

--- a/hubblestack_nova/modules/win_firewall.py
+++ b/hubblestack_nova/modules/win_firewall.py
@@ -25,13 +25,16 @@ def __virtual__():
     return True
 
 
-def audit(data_list, tags, verbose=False):
+def audit(data_list, tags, verbose=False, show_profile=False):
     '''Runs auditpol on the local machine and audits the return data
     with the CIS yaml processed by __virtual__'''
     __data__ = {}
     __firewalldata__ = _import_firewall()
-    for data in data_list:
-        _merge_yaml(__data__, data)
+    for profile, data in data_list:
+        if show_profile:
+            _merge_yaml(__data__, data, profile)
+        else:
+            _merge_yaml(__data__, data)
     __tags__ = _get_tags(__data__)
     log.trace('firewall audit __data__:')
     log.trace(__data__)
@@ -115,7 +118,7 @@ def audit(data_list, tags, verbose=False):
     return ret
 
 
-def _merge_yaml(ret, data):
+def _merge_yaml(ret, data, profile=None):
     '''
     Merge two yaml dicts together at the secedit:blacklist and
     secedit:whitelist level
@@ -127,6 +130,8 @@ def _merge_yaml(ret, data):
             if topkey not in ret[__virtualname__]:
                 ret[__virtualname__][topkey] = []
             for key, val in data[__virtualname__][topkey].iteritems():
+                if profile and 'data' in val:
+                    val['data']['nova_profile'] = profile
                 ret[__virtualname__][topkey].append({key: val})
     return ret
 

--- a/hubblestack_nova/modules/win_firewall.py
+++ b/hubblestack_nova/modules/win_firewall.py
@@ -73,11 +73,12 @@ def audit(data_list, tags, verbose=False, show_profile=False):
                         log.debug('When trying to audit the firewall section,'
                                   ' the yaml contained incorrect data for the key')
 
-    if not verbose:
-        failure = []
-        success = []
-        controlled = []
+    failure = []
+    success = []
+    controlled = []
 
+    if not verbose:
+        # Pull out just the tag and description
         tags_descriptions = set()
 
         for tag_data in ret['Failure']:
@@ -108,9 +109,23 @@ def audit(data_list, tags, verbose=False, show_profile=False):
                 controlled.append({tag: description})
                 control_reasons.add((tag, description, control_reason))
 
-        ret['Controlled'] = controlled
-        ret['Success'] = success
-        ret['Failure'] = failure
+    else:
+        # Format verbose output as single-key dictionaries with tag as key
+        for tag_data in ret['Failure']:
+            tag = tag_data['tag']
+            failure.append({tag: tag_data})
+
+        for tag_data in ret['Success']:
+            tag = tag_data['tag']
+            success.append({tag: tag_data})
+
+        for tag_data in ret['Controlled']:
+            tag = tag_data['tag']
+            controlled.append({tag: tag_data})
+
+    ret['Controlled'] = controlled
+    ret['Success'] = success
+    ret['Failure'] = failure
 
     if not ret['Controlled']:
         ret.pop('Controlled')
@@ -130,8 +145,8 @@ def _merge_yaml(ret, data, profile=None):
             if topkey not in ret[__virtualname__]:
                 ret[__virtualname__][topkey] = []
             for key, val in data[__virtualname__][topkey].iteritems():
-                if profile and 'data' in val:
-                    val['data']['nova_profile'] = profile
+                if profile and isinstance(val, dict):
+                    val['nova_profile'] = profile
                 ret[__virtualname__][topkey].append({key: val})
     return ret
 

--- a/hubblestack_nova/modules/win_gp.py
+++ b/hubblestack_nova/modules/win_gp.py
@@ -72,11 +72,12 @@ def audit(data_list, tags, verbose=False, show_profile=False):
                         log.debug('When trying to audit the firewall section,'
                                   ' the yaml contained incorrect data for the key')
 
-    if not verbose:
-        failure = []
-        success = []
-        controlled = []
+    failure = []
+    success = []
+    controlled = []
 
+    if not verbose:
+        # Pull out just the tag and description
         tags_descriptions = set()
 
         for tag_data in ret['Failure']:
@@ -107,9 +108,23 @@ def audit(data_list, tags, verbose=False, show_profile=False):
                 controlled.append({tag: description})
                 control_reasons.add((tag, description, control_reason))
 
-        ret['Controlled'] = controlled
-        ret['Success'] = success
-        ret['Failure'] = failure
+    else:
+        # Format verbose output as single-key dictionaries with tag as key
+        for tag_data in ret['Failure']:
+            tag = tag_data['tag']
+            failure.append({tag: tag_data})
+
+        for tag_data in ret['Success']:
+            tag = tag_data['tag']
+            success.append({tag: tag_data})
+
+        for tag_data in ret['Controlled']:
+            tag = tag_data['tag']
+            controlled.append({tag: tag_data})
+
+    ret['Controlled'] = controlled
+    ret['Success'] = success
+    ret['Failure'] = failure
 
     if not ret['Controlled']:
         ret.pop('Controlled')
@@ -129,8 +144,8 @@ def _merge_yaml(ret, data, profile=None):
             if topkey not in ret[__virtualname__]:
                 ret[__virtualname__][topkey] = []
             for key, val in data[__virtualname__][topkey].iteritems():
-                if profile and 'data' in val:
-                    val['data']['nova_profile'] = profile
+                if profile and isinstance(val, dict):
+                    val['nova_profile'] = profile
                 ret[__virtualname__][topkey].append({key: val})
     return ret
 

--- a/hubblestack_nova/modules/win_gp.py
+++ b/hubblestack_nova/modules/win_gp.py
@@ -25,13 +25,16 @@ def __virtual__():
     return True
 
 
-def audit(data_list, tags, verbose=False):
+def audit(data_list, tags, verbose=False, show_profile=False):
     '''Runs auditpol on the local machine and audits the return data
     with the CIS yaml processed by __virtual__'''
     __data__ = {}
     __gpdata__ = _get_gp_templates()
-    for data in data_list:
-        _merge_yaml(__data__, data)
+    for profile, data in data_list:
+        if show_profile:
+            _merge_yaml(__data__, data, profile)
+        else:
+            _merge_yaml(__data__, data)
     __tags__ = _get_tags(__data__)
     log.trace('firewall audit __data__:')
     log.trace(__data__)
@@ -114,7 +117,7 @@ def audit(data_list, tags, verbose=False):
     return ret
 
 
-def _merge_yaml(ret, data):
+def _merge_yaml(ret, data, profile=None):
     '''
     Merge two yaml dicts together at the secedit:blacklist and
     secedit:whitelist level
@@ -126,6 +129,8 @@ def _merge_yaml(ret, data):
             if topkey not in ret[__virtualname__]:
                 ret[__virtualname__][topkey] = []
             for key, val in data[__virtualname__][topkey].iteritems():
+                if profile and 'data' in val:
+                    val['data']['nova_profile'] = profile
                 ret[__virtualname__][topkey].append({key: val})
     return ret
 

--- a/hubblestack_nova/modules/win_pkg.py
+++ b/hubblestack_nova/modules/win_pkg.py
@@ -70,11 +70,12 @@ def audit(data_list, tags, verbose=False, show_profile=False):
                     else:
                         ret['Failure'].append(tag_data)
 
-    if not verbose:
-        failure = []
-        success = []
-        controlled = []
+    failure = []
+    success = []
+    controlled = []
 
+    if not verbose:
+        # Pull out just the tag and description
         tags_descriptions = set()
 
         for tag_data in ret['Failure']:
@@ -105,9 +106,23 @@ def audit(data_list, tags, verbose=False, show_profile=False):
                 controlled.append({tag: description})
                 control_reasons.add((tag, description, control_reason))
 
-        ret['Controlled'] = controlled
-        ret['Success'] = success
-        ret['Failure'] = failure
+    else:
+        # Format verbose output as single-key dictionaries with tag as key
+        for tag_data in ret['Failure']:
+            tag = tag_data['tag']
+            failure.append({tag: tag_data})
+
+        for tag_data in ret['Success']:
+            tag = tag_data['tag']
+            success.append({tag: tag_data})
+
+        for tag_data in ret['Controlled']:
+            tag = tag_data['tag']
+            controlled.append({tag: tag_data})
+
+    ret['Controlled'] = controlled
+    ret['Success'] = success
+    ret['Failure'] = failure
 
     if not ret['Controlled']:
         ret.pop('Controlled')
@@ -127,8 +142,8 @@ def _merge_yaml(ret, data, profile=None):
             if topkey not in ret[__virtualname__]:
                 ret[__virtualname__][topkey] = []
             for key, val in data[__virtualname__][topkey].iteritems():
-                if profile and 'data' in val:
-                    val['data']['nova_profile'] = profile
+                if profile and isinstance(val, dict):
+                    val['nova_profile'] = profile
                 ret[__virtualname__][topkey].append({key: val})
     return ret
 

--- a/hubblestack_nova/modules/win_pkg.py
+++ b/hubblestack_nova/modules/win_pkg.py
@@ -24,13 +24,16 @@ def __virtual__():
     return True
 
 
-def audit(data_list, tags, verbose=False):
+def audit(data_list, tags, verbose=False, show_profile=False):
     '''Runs auditpol on the local machine and audits the return data
     with the CIS yaml processed by __virtual__'''
     __data__ = {}
     __pkgdata__ = __salt__['pkg.list_pkgs']()
-    for data in data_list:
-        _merge_yaml(__data__, data)
+    for profile, data in data_list:
+        if show_profile:
+            _merge_yaml(__data__, data, profile)
+        else:
+            _merge_yaml(__data__, data)
     __tags__ = _get_tags(__data__)
     log.trace('package audit __data__:')
     log.trace(__data__)
@@ -112,7 +115,7 @@ def audit(data_list, tags, verbose=False):
     return ret
 
 
-def _merge_yaml(ret, data):
+def _merge_yaml(ret, data, profile=None):
     '''
     Merge two yaml dicts together at the secedit:blacklist and
     secedit:whitelist level
@@ -124,6 +127,8 @@ def _merge_yaml(ret, data):
             if topkey not in ret[__virtualname__]:
                 ret[__virtualname__][topkey] = []
             for key, val in data[__virtualname__][topkey].iteritems():
+                if profile and 'data' in val:
+                    val['data']['nova_profile'] = profile
                 ret[__virtualname__][topkey].append({key: val})
     return ret
 

--- a/hubblestack_nova/modules/win_reg.py
+++ b/hubblestack_nova/modules/win_reg.py
@@ -85,11 +85,12 @@ def audit(data_list, tags, verbose=False, show_profile=False):
                         ret['Failure'].append(tag_data)
 
 
-    if not verbose:
-        failure = []
-        success = []
-        controlled = []
+    failure = []
+    success = []
+    controlled = []
 
+    if not verbose:
+        # Pull out just the tag and description
         tags_descriptions = set()
 
         for tag_data in ret['Failure']:
@@ -120,9 +121,23 @@ def audit(data_list, tags, verbose=False, show_profile=False):
                 controlled.append({tag: description})
                 control_reasons.add((tag, description, control_reason))
 
-        ret['Controlled'] = controlled
-        ret['Success'] = success
-        ret['Failure'] = failure
+    else:
+        # Format verbose output as single-key dictionaries with tag as key
+        for tag_data in ret['Failure']:
+            tag = tag_data['tag']
+            failure.append({tag: tag_data})
+
+        for tag_data in ret['Success']:
+            tag = tag_data['tag']
+            success.append({tag: tag_data})
+
+        for tag_data in ret['Controlled']:
+            tag = tag_data['tag']
+            controlled.append({tag: tag_data})
+
+    ret['Controlled'] = controlled
+    ret['Success'] = success
+    ret['Failure'] = failure
 
     if not ret['Controlled']:
         ret.pop('Controlled')
@@ -142,8 +157,8 @@ def _merge_yaml(ret, data, profile=None):
             if topkey not in ret[__virtualname__]:
                 ret[__virtualname__][topkey] = []
             for key, val in data[__virtualname__][topkey].iteritems():
-                if profile and 'data' in val:
-                    val['data']['nova_profile'] = profile
+                if profile and isinstance(val, dict):
+                    val['nova_profile'] = profile
                 ret[__virtualname__][topkey].append({key: val})
     return ret
 

--- a/hubblestack_nova/modules/win_reg.py
+++ b/hubblestack_nova/modules/win_reg.py
@@ -24,12 +24,15 @@ def __virtual__():
     return True
 
 
-def audit(data_list, tags, verbose=False):
+def audit(data_list, tags, verbose=False, show_profile=False):
     '''Runs auditpol on the local machine and audits the return data
     with the CIS yaml processed by __virtual__'''
     __data__ = {}
-    for data in data_list:
-        _merge_yaml(__data__, data)
+    for profile, data in data_list:
+        if show_profile:
+            _merge_yaml(__data__, data, profile)
+        else:
+            _merge_yaml(__data__, data)
     __tags__ = _get_tags(__data__)
     log.trace('registry audit __data__:')
     log.trace(__data__)
@@ -127,7 +130,7 @@ def audit(data_list, tags, verbose=False):
     return ret
 
 
-def _merge_yaml(ret, data):
+def _merge_yaml(ret, data, profile=None):
     '''
     Merge two yaml dicts together at the secedit:blacklist and
     secedit:whitelist level
@@ -139,6 +142,8 @@ def _merge_yaml(ret, data):
             if topkey not in ret[__virtualname__]:
                 ret[__virtualname__][topkey] = []
             for key, val in data[__virtualname__][topkey].iteritems():
+                if profile and 'data' in val:
+                    val['data']['nova_profile'] = profile
                 ret[__virtualname__][topkey].append({key: val})
     return ret
 

--- a/hubblestack_nova/modules/win_secedit.py
+++ b/hubblestack_nova/modules/win_secedit.py
@@ -92,11 +92,12 @@ def audit(data_list, tags, verbose=False, show_profile=False):
                     else:
                         ret['Failure'].append(tag_data)
 
-    if not verbose:
-        failure = []
-        success = []
-        controlled = []
+    failure = []
+    success = []
+    controlled = []
 
+    if not verbose:
+        # Pull out just the tag and description
         tags_descriptions = set()
 
         for tag_data in ret['Failure']:
@@ -127,9 +128,23 @@ def audit(data_list, tags, verbose=False, show_profile=False):
                 controlled.append({tag: description})
                 control_reasons.add((tag, description, control_reason))
 
-        ret['Controlled'] = controlled
-        ret['Success'] = success
-        ret['Failure'] = failure
+    else:
+        # Format verbose output as single-key dictionaries with tag as key
+        for tag_data in ret['Failure']:
+            tag = tag_data['tag']
+            failure.append({tag: tag_data})
+
+        for tag_data in ret['Success']:
+            tag = tag_data['tag']
+            success.append({tag: tag_data})
+
+        for tag_data in ret['Controlled']:
+            tag = tag_data['tag']
+            controlled.append({tag: tag_data})
+
+    ret['Controlled'] = controlled
+    ret['Success'] = success
+    ret['Failure'] = failure
 
     if not ret['Controlled']:
         ret.pop('Controlled')
@@ -149,8 +164,8 @@ def _merge_yaml(ret, data, profile=None):
             if topkey not in ret[__virtualname__]:
                 ret[__virtualname__][topkey] = []
             for key, val in data[__virtualname__][topkey].iteritems():
-                if profile and 'data' in val:
-                    val['data']['nova_profile'] = profile
+                if profile and isinstance(val, dict):
+                    val['nova_profile'] = profile
                 ret[__virtualname__][topkey].append({key: val})
     return ret
 

--- a/hubblestack_nova/modules/win_secedit.py
+++ b/hubblestack_nova/modules/win_secedit.py
@@ -30,14 +30,17 @@ def __virtual__():
     return True
 
 
-def audit(data_list, tags, verbose=False):
+def audit(data_list, tags, verbose=False, show_profile=False):
     '''Runs secedit on the local machine and audits the return data
     with the CIS yaml processed by __virtual__'''
     __data__ = {}
     __secdata__ = _secedit_export()
     __sidaccounts__ = _get_account_sid()
-    for data in data_list:
-        _merge_yaml(__data__, data)
+    for profile, data in data_list:
+        if show_profile:
+            _merge_yaml(__data__, data, profile)
+        else:
+            _merge_yaml(__data__, data)
     __tags__ = _get_tags(__data__)
     log.trace('secedit audit __data__:')
     log.trace(__data__)
@@ -134,7 +137,7 @@ def audit(data_list, tags, verbose=False):
     return ret
 
 
-def _merge_yaml(ret, data):
+def _merge_yaml(ret, data, profile=None):
     '''
     Merge two yaml dicts together at the secedit:blacklist and
     secedit:whitelist level
@@ -146,6 +149,8 @@ def _merge_yaml(ret, data):
             if topkey not in ret[__virtualname__]:
                 ret[__virtualname__][topkey] = []
             for key, val in data[__virtualname__][topkey].iteritems():
+                if profile and 'data' in val:
+                    val['data']['nova_profile'] = profile
                 ret[__virtualname__][topkey].append({key: val})
     return ret
 


### PR DESCRIPTION
Add show_profile argument to show the nova profile from which a check was sourced

The `nova_profile` key will be injected in the main data dictionary for checks.

@madchills @cedwards @jaredhanson11 @avb76 Note that this changes the format of the `data_list` which is passed to each module. It is now a list of tuples in the form of `(profile_name, profile_data)`.

Additionally, all new nova modules must take in the `show_profile` argument. Not ideal, but I couldn't figure out how else to accomplish this feature with the way things were architected. `hubble.py` didn't have enough information to make these changes.

I should also note that verbose output is now in the form of `tag: data` just like non-verbose output. This was not always the case previously.

Oh, and https://github.com/HubbleStack/Nova/pull/197/commits/d9359640045c464528453d002ff88457e7008758 was to fix a couple of erroneous entries in the new CIS profiles. Not sure how they got there.
