### PR TITLE
Remove trace logs to work around #204

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -253,7 +253,7 @@ include full documentation
         return True
 
 
-    def audit(data_list, tag, verbose=False, show_profile=False):
+    def audit(data_list, tag, verbose=False, show_profile=False, debug=False):
         __tags__ = []
         for profile, data in data_list:
             # This is where you process the dictionaries passed in by hubble.py,
@@ -280,16 +280,18 @@ compatibility, and an ``audit()`` function to perform the actual audit
 functionality
 
 The ``audit()`` function must take four arguments, ``data_list``, ``tag``,
-``verbose``, and ``show_profile``. The ``data_list`` argument is a list of dictionaries passed in by
-``hubble.py``. ``hubble.py`` gets this data from loading the specified yaml for
-the audit run. Your audit module should only run if it finds its own data in
-this list. The ``tag`` argument is a glob expression for which tags the audit
-function should run. It is the job of the audit module to compare the ``tag``
-glob with all tags supported by this module and only run the audits which
-match. The ``verbose`` argument defines whether additional information should
-be returned for audits, such as description and remediation instructions. The
-``show_profile`` argument tells whether the profile should be injected into
-the verbose data for each check.
+``verbose``, ``show_profile``, and ``debug``. The ``data_list`` argument is a
+list of dictionaries passed in by ``hubble.py``. ``hubble.py`` gets this data
+from loading the specified yaml for the audit run. Your audit module should
+only run if it finds its own data in this list. The ``tag`` argument is a glob
+expression for which tags the audit function should run. It is the job of the
+audit module to compare the ``tag`` glob with all tags supported by this module
+and only run the audits which match. The ``verbose`` argument defines whether
+additional information should be returned for audits, such as description and
+remediation instructions. The ``show_profile`` argument tells whether the
+profile should be injected into the verbose data for each check. The ``debug``
+argument tells whether the module should log additional debugging information
+at debug log level.
 
 The return value should be a dictionary, with optional keys "Success",
 "Failure", and "Controlled". The values for these keys should be a list of

--- a/hubblestack_nova/modules/command.py
+++ b/hubblestack_nova/modules/command.py
@@ -82,7 +82,7 @@ def __virtual__():
     return True
 
 
-def audit(data_list, tags, verbose=False, show_profile=False):
+def audit(data_list, tags, verbose=False, show_profile=False, debug=False):
     '''
     Run the command audits contained in the data_list
     '''
@@ -94,10 +94,11 @@ def audit(data_list, tags, verbose=False, show_profile=False):
             _merge_yaml(__data__, data)
     __tags__ = _get_tags(__data__)
 
-    log.trace('command audit __data__:')
-    log.trace(__data__)
-    log.trace('command audit __tags__:')
-    log.trace(__tags__)
+    if debug:
+        log.debug('command audit __data__:')
+        log.debug(__data__)
+        log.debug('command audit __tags__:')
+        log.debug(__tags__)
 
     ret = {'Success': [], 'Failure': [], 'Controlled': []}
     for tag in __tags__:

--- a/hubblestack_nova/modules/cve_scan.py
+++ b/hubblestack_nova/modules/cve_scan.py
@@ -21,7 +21,7 @@ def __virtual__():
     return False, 'This module requires Linux and the oscap binary'
 
 
-def audit(data_list, tags, verbose=False, show_profile=False):
+def audit(data_list, tags, verbose=False, show_profile=False, debug=False):
     '''
     Run the network.netstat command
     '''

--- a/hubblestack_nova/modules/cve_scan_v2.py
+++ b/hubblestack_nova/modules/cve_scan_v2.py
@@ -92,7 +92,7 @@ def __virtual__():
     return not salt.utils.is_windows()
 
 
-def audit(data_list, tags, verbose=False, show_profile=False):
+def audit(data_list, tags, verbose=False, show_profile=False, debug=False):
     '''
     Main audit function. See module docstring for more information on usage.
     '''

--- a/hubblestack_nova/modules/firewall.py
+++ b/hubblestack_nova/modules/firewall.py
@@ -99,7 +99,7 @@ def __virtual__():
     return True
 
 
-def audit(data_list, tags, verbose=False, show_profile=False):
+def audit(data_list, tags, verbose=False, show_profile=False, debug=False):
     __data__ = {}
     for profile, data in data_list:
         if show_profile:
@@ -108,10 +108,11 @@ def audit(data_list, tags, verbose=False, show_profile=False):
             _merge_yaml(__data__, data)
     __tags__ = _get_tags(__data__)
 
-    log.trace('service audit __data__:')
-    log.trace(__data__)
-    log.trace('service audit __tags__:')
-    log.trace(__tags__)
+    if debug:
+        log.debug('service audit __data__:')
+        log.debug(__data__)
+        log.debug('service audit __tags__:')
+        log.debug(__tags__)
 
     ret = {'Success': [], 'Failure': [], 'Controlled': []}
     for tag in __tags__:

--- a/hubblestack_nova/modules/grep.py
+++ b/hubblestack_nova/modules/grep.py
@@ -73,7 +73,7 @@ def __virtual__():
     return True
 
 
-def audit(data_list, tags, verbose=False, show_profile=False):
+def audit(data_list, tags, verbose=False, show_profile=False, debug=False):
     '''
     Run the grep audits contained in the YAML files processed by __virtual__
     '''
@@ -85,10 +85,11 @@ def audit(data_list, tags, verbose=False, show_profile=False):
             _merge_yaml(__data__, data)
     __tags__ = _get_tags(__data__)
 
-    log.trace('grep audit __data__:')
-    log.trace(__data__)
-    log.trace('grep audit __tags__:')
-    log.trace(__tags__)
+    if debug:
+        log.debug('grep audit __data__:')
+        log.debug(__data__)
+        log.debug('grep audit __tags__:')
+        log.debug(__tags__)
 
     ret = {'Success': [], 'Failure': [], 'Controlled': []}
     for tag in __tags__:

--- a/hubblestack_nova/modules/netstat.py
+++ b/hubblestack_nova/modules/netstat.py
@@ -36,7 +36,7 @@ def __virtual__():
     return False, 'No network.netstat function found'
 
 
-def audit(data_list, tags, verbose=False, show_profile=False):
+def audit(data_list, tags, verbose=False, show_profile=False, debug=True):
     '''
     Run the network.netstat command
     '''

--- a/hubblestack_nova/modules/openssl.py
+++ b/hubblestack_nova/modules/openssl.py
@@ -99,7 +99,7 @@ def __virtual__():
     return True
 
 
-def audit(data_list, tags, verbose=False, show_profile=False):
+def audit(data_list, tags, verbose=False, show_profile=False, debug=True):
     __data__ = {}
     for profile, data in data_list:
         if show_profile:
@@ -108,10 +108,11 @@ def audit(data_list, tags, verbose=False, show_profile=False):
             _merge_yaml(__data__, data)
     __tags__ = _get_tags(__data__)
 
-    log.trace('service audit __data__:')
-    log.trace(__data__)
-    log.trace('service audit __tags__:')
-    log.trace(__tags__)
+    if debug:
+        log.debug('service audit __data__:')
+        log.debug(__data__)
+        log.debug('service audit __tags__:')
+        log.debug(__tags__)
 
     ret = {'Success': [], 'Failure': [], 'Controlled': []}
     for tag in __tags__:

--- a/hubblestack_nova/modules/pkg.py
+++ b/hubblestack_nova/modules/pkg.py
@@ -79,7 +79,7 @@ def __virtual__():
     return True
 
 
-def audit(data_list, tags, verbose=False, show_profile=False):
+def audit(data_list, tags, verbose=False, show_profile=False, debug=False):
     '''
     Run the pkg audits contained in the YAML files processed by __virtual__
     '''
@@ -91,10 +91,11 @@ def audit(data_list, tags, verbose=False, show_profile=False):
             _merge_yaml(__data__, data)
     __tags__ = _get_tags(__data__)
 
-    log.trace('pkg audit __data__:')
-    log.trace(__data__)
-    log.trace('pkg audit __tags__:')
-    log.trace(__tags__)
+    if debug:
+        log.debug('pkg audit __data__:')
+        log.debug(__data__)
+        log.debug('pkg audit __tags__:')
+        log.debug(__tags__)
 
     ret = {'Success': [], 'Failure': [], 'Controlled': []}
     for tag in __tags__:

--- a/hubblestack_nova/modules/pkgng_audit.py
+++ b/hubblestack_nova/modules/pkgng_audit.py
@@ -20,7 +20,7 @@ def __virtual__():
     return True
 
 
-def audit(data_list, tags, verbose=False, show_profile=False):
+def audit(data_list, tags, verbose=False, show_profile=False, debug=False):
     '''
     Run the pkg.audit command
     '''
@@ -32,8 +32,9 @@ def audit(data_list, tags, verbose=False, show_profile=False):
             __tags__ = ['pkgng_audit']
             break
 
-    log.trace('pkgng audit __tags__:')
-    log.trace(__tags__)
+    if debug:
+        log.debug('pkgng audit __tags__:')
+        log.debug(__tags__)
 
     if not __tags__:
         # No yaml data found, don't do any work

--- a/hubblestack_nova/modules/service.py
+++ b/hubblestack_nova/modules/service.py
@@ -72,7 +72,7 @@ def __virtual__():
     return True
 
 
-def audit(data_list, tags, verbose=False, show_profile=False):
+def audit(data_list, tags, verbose=False, show_profile=False, debug=False):
     '''
     Run the service audits contained in the YAML files processed by __virtual__
     '''
@@ -84,10 +84,11 @@ def audit(data_list, tags, verbose=False, show_profile=False):
             _merge_yaml(__data__, data)
     __tags__ = _get_tags(__data__)
 
-    log.trace('service audit __data__:')
-    log.trace(__data__)
-    log.trace('service audit __tags__:')
-    log.trace(__tags__)
+    if debug:
+        log.debug('service audit __data__:')
+        log.debug(__data__)
+        log.debug('service audit __tags__:')
+        log.debug(__tags__)
 
     ret = {'Success': [], 'Failure': [], 'Controlled': []}
     for tag in __tags__:

--- a/hubblestack_nova/modules/stat.py
+++ b/hubblestack_nova/modules/stat.py
@@ -57,7 +57,7 @@ def __virtual__():
     return True
 
 
-def audit(data_list, tags, verbose=False, show_profile=False):
+def audit(data_list, tags, verbose=False, show_profile=False, debug=False):
     '''
     Run the stat audits contained in the YAML files processed by __virtual__
     '''
@@ -69,10 +69,11 @@ def audit(data_list, tags, verbose=False, show_profile=False):
             _merge_yaml(__data__, data)
     __tags__ = _get_tags(__data__)
 
-    log.trace('service audit __data__:')
-    log.trace(__data__)
-    log.trace('service audit __tags__:')
-    log.trace(__tags__)
+    if debug:
+        log.debug('service audit __data__:')
+        log.debug(__data__)
+        log.debug('service audit __tags__:')
+        log.debug(__tags__)
 
     ret = {'Success': [], 'Failure': [], 'Controlled': []}
 

--- a/hubblestack_nova/modules/sysctl.py
+++ b/hubblestack_nova/modules/sysctl.py
@@ -49,7 +49,7 @@ def __virtual__():
     return True
 
 
-def audit(data_list, tags, verbose=False, show_profile=False):
+def audit(data_list, tags, verbose=False, show_profile=False, debug=False):
     '''
     Run the sysctl audits contained in the YAML files processed by __virtual__
     '''
@@ -61,10 +61,11 @@ def audit(data_list, tags, verbose=False, show_profile=False):
             _merge_yaml(__data__, data)
     __tags__ = _get_tags(__data__)
 
-    log.trace('service audit __data__:')
-    log.trace(__data__)
-    log.trace('service audit __tags__:')
-    log.trace(__tags__)
+    if debug:
+        log.debug('service audit __data__:')
+        log.debug(__data__)
+        log.debug('service audit __tags__:')
+        log.debug(__tags__)
 
     ret = {'Success': [], 'Failure': [], 'Controlled': []}
 

--- a/hubblestack_nova/modules/win_auditpol.py
+++ b/hubblestack_nova/modules/win_auditpol.py
@@ -25,9 +25,11 @@ def __virtual__():
     return True
 
 
-def audit(data_list, tags, verbose=False, show_profile=False):
-    '''Runs auditpol on the local machine and audits the return data
-    with the CIS yaml processed by __virtual__'''
+def audit(data_list, tags, verbose=False, show_profile=False, debug=False):
+    '''
+    Runs auditpol on the local machine and audits the return data
+    with the CIS yaml processed by __virtual__
+    '''
     __data__ = {}
     __auditdata__ = _auditpol_import()
     for profile, data in data_list:
@@ -36,10 +38,11 @@ def audit(data_list, tags, verbose=False, show_profile=False):
         else:
             _merge_yaml(__data__, data)
     __tags__ = _get_tags(__data__)
-    log.trace('auditpol audit __data__:')
-    log.trace(__data__)
-    log.trace('auditpol audit __tags__:')
-    log.trace(__tags__)
+    if debug:
+        log.debug('auditpol audit __data__:')
+        log.debug(__data__)
+        log.debug('auditpol audit __tags__:')
+        log.debug(__tags__)
 
     ret = {'Success': [], 'Failure': [], 'Controlled': []}
     for tag in __tags__:

--- a/hubblestack_nova/modules/win_firewall.py
+++ b/hubblestack_nova/modules/win_firewall.py
@@ -25,9 +25,11 @@ def __virtual__():
     return True
 
 
-def audit(data_list, tags, verbose=False, show_profile=False):
-    '''Runs auditpol on the local machine and audits the return data
-    with the CIS yaml processed by __virtual__'''
+def audit(data_list, tags, verbose=False, show_profile=False, debug=False):
+    '''
+    Runs auditpol on the local machine and audits the return data
+    with the CIS yaml processed by __virtual__
+    '''
     __data__ = {}
     __firewalldata__ = _import_firewall()
     for profile, data in data_list:
@@ -36,10 +38,11 @@ def audit(data_list, tags, verbose=False, show_profile=False):
         else:
             _merge_yaml(__data__, data)
     __tags__ = _get_tags(__data__)
-    log.trace('firewall audit __data__:')
-    log.trace(__data__)
-    log.trace('firewall audit __tags__:')
-    log.trace(__tags__)
+    if debug:
+        log.debug('firewall audit __data__:')
+        log.debug(__data__)
+        log.debug('firewall audit __tags__:')
+        log.debug(__tags__)
 
     ret = {'Success': [], 'Failure': [], 'Controlled': []}
     for tag in __tags__:

--- a/hubblestack_nova/modules/win_gp.py
+++ b/hubblestack_nova/modules/win_gp.py
@@ -25,9 +25,11 @@ def __virtual__():
     return True
 
 
-def audit(data_list, tags, verbose=False, show_profile=False):
-    '''Runs auditpol on the local machine and audits the return data
-    with the CIS yaml processed by __virtual__'''
+def audit(data_list, tags, verbose=False, show_profile=False, debug=False):
+    '''
+    Runs auditpol on the local machine and audits the return data
+    with the CIS yaml processed by __virtual__
+    '''
     __data__ = {}
     __gpdata__ = _get_gp_templates()
     for profile, data in data_list:
@@ -36,10 +38,11 @@ def audit(data_list, tags, verbose=False, show_profile=False):
         else:
             _merge_yaml(__data__, data)
     __tags__ = _get_tags(__data__)
-    log.trace('firewall audit __data__:')
-    log.trace(__data__)
-    log.trace('firewall audit __tags__:')
-    log.trace(__tags__)
+    if debug:
+        log.debug('firewall audit __data__:')
+        log.debug(__data__)
+        log.debug('firewall audit __tags__:')
+        log.debug(__tags__)
 
     ret = {'Success': [], 'Failure': [], 'Controlled': []}
     for tag in __tags__:

--- a/hubblestack_nova/modules/win_pkg.py
+++ b/hubblestack_nova/modules/win_pkg.py
@@ -24,9 +24,11 @@ def __virtual__():
     return True
 
 
-def audit(data_list, tags, verbose=False, show_profile=False):
-    '''Runs auditpol on the local machine and audits the return data
-    with the CIS yaml processed by __virtual__'''
+def audit(data_list, tags, verbose=False, show_profile=False, debug=False):
+    '''
+    Runs auditpol on the local machine and audits the return data
+    with the CIS yaml processed by __virtual__
+    '''
     __data__ = {}
     __pkgdata__ = __salt__['pkg.list_pkgs']()
     for profile, data in data_list:
@@ -35,10 +37,11 @@ def audit(data_list, tags, verbose=False, show_profile=False):
         else:
             _merge_yaml(__data__, data)
     __tags__ = _get_tags(__data__)
-    log.trace('package audit __data__:')
-    log.trace(__data__)
-    log.trace('package audit __tags__:')
-    log.trace(__tags__)
+    if debug:
+        log.debug('package audit __data__:')
+        log.debug(__data__)
+        log.debug('package audit __tags__:')
+        log.debug(__tags__)
 
     ret = {'Success': [], 'Failure': [], 'Controlled': []}
     for tag in __tags__:

--- a/hubblestack_nova/modules/win_reg.py
+++ b/hubblestack_nova/modules/win_reg.py
@@ -24,9 +24,11 @@ def __virtual__():
     return True
 
 
-def audit(data_list, tags, verbose=False, show_profile=False):
-    '''Runs auditpol on the local machine and audits the return data
-    with the CIS yaml processed by __virtual__'''
+def audit(data_list, tags, verbose=False, show_profile=False, debug=False):
+    '''
+    Runs auditpol on the local machine and audits the return data
+    with the CIS yaml processed by __virtual__
+    '''
     __data__ = {}
     for profile, data in data_list:
         if show_profile:
@@ -34,10 +36,11 @@ def audit(data_list, tags, verbose=False, show_profile=False):
         else:
             _merge_yaml(__data__, data)
     __tags__ = _get_tags(__data__)
-    log.trace('registry audit __data__:')
-    log.trace(__data__)
-    log.trace('registry audit __tags__:')
-    log.trace(__tags__)
+    if debug:
+        log.debug('registry audit __data__:')
+        log.debug(__data__)
+        log.debug('registry audit __tags__:')
+        log.debug(__tags__)
 
     ret = {'Success': [], 'Failure': [], 'Controlled': []}
     for tag in __tags__:

--- a/hubblestack_nova/modules/win_secedit.py
+++ b/hubblestack_nova/modules/win_secedit.py
@@ -30,9 +30,11 @@ def __virtual__():
     return True
 
 
-def audit(data_list, tags, verbose=False, show_profile=False):
-    '''Runs secedit on the local machine and audits the return data
-    with the CIS yaml processed by __virtual__'''
+def audit(data_list, tags, verbose=False, show_profile=False, debug=False):
+    '''
+    Runs secedit on the local machine and audits the return data
+    with the CIS yaml processed by __virtual__
+    '''
     __data__ = {}
     __secdata__ = _secedit_export()
     __sidaccounts__ = _get_account_sid()
@@ -42,10 +44,11 @@ def audit(data_list, tags, verbose=False, show_profile=False):
         else:
             _merge_yaml(__data__, data)
     __tags__ = _get_tags(__data__)
-    log.trace('secedit audit __data__:')
-    log.trace(__data__)
-    log.trace('secedit audit __tags__:')
-    log.trace(__tags__)
+    if debug:
+        log.debug('secedit audit __data__:')
+        log.debug(__data__)
+        log.debug('secedit audit __tags__:')
+        log.debug(__tags__)
 
     ret = {'Success': [], 'Failure': [], 'Controlled': []}
     for tag in __tags__:


### PR DESCRIPTION
New passthrough arg `debug` just for the purposes of logging that we only want sometimes, since we can't safely use trace logs.
