### PR TITLE
Turn off sync cleaning by default, reduce verbosity of grep failures in logs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -223,6 +223,7 @@ In order to run the audits once daily, you can use the following schedule:
           show_profile: True
         returner: splunk_nova_return
         return_job: False
+        run_on_start: False
 
 .. _nova_configuration:
 

--- a/_modules/hubble.py
+++ b/_modules/hubble.py
@@ -415,7 +415,7 @@ def top(topfile='top.nova',
     return results
 
 
-def sync():
+def sync(clean=False):
     '''
     Sync the nova audit modules and profiles from the saltstack fileserver.
 
@@ -433,8 +433,9 @@ def sync():
 
     Returns a boolean representing success
 
-    NOTE: This function will also clean out existing files at the cached
-    location, as cp.cache_dir doesn't clean out old files
+    NOTE: This function will optionally clean out existing files at the cached
+    location, as cp.cache_dir doesn't clean out old files. Pass ``clean=True``
+    to enable this behavior
 
     CLI Examples:
 
@@ -451,8 +452,9 @@ def sync():
     saltenv = __salt__['config.get']('hubblestack:nova:saltenv', 'base')
 
     # Clean previously synced files
-    for nova_dir in _hubble_dir():
-        __salt__['file.remove'](nova_dir)
+    if clean:
+        for nova_dir in _hubble_dir():
+            __salt__['file.remove'](nova_dir)
 
     synced = []
     for i, nova_dir in enumerate((nova_module_dir, nova_profile_dir)):


### PR DESCRIPTION
Had to bring in the `file.grep` function from salt explicitly, so I could `ignore_retcode=True`. That way the logs will not error for every nonzero retcode on the greps.

Also turned off cache cleaning by default. (Clean only necessary if we delete files.)
