### PR TITLE
Add leading slash in path for /etc/cron.hourly

### DIFF
--- a/hubblestack_nova_profiles/cis/centos-6-level-1-scored-v2-0-1.yaml
+++ b/hubblestack_nova_profiles/cis/centos-6-level-1-scored-v2-0-1.yaml
@@ -151,7 +151,7 @@ stat:
   cron_hourly:
     data:
       'CentOS-6':
-        - 'etc/cron.hourly':
+        - '/etc/cron.hourly':
             tag: CIS-5.1.3
             mode: 700
             user: 'root'

--- a/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v1.yaml
+++ b/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v1.yaml
@@ -503,7 +503,7 @@ stat:
   cron_hourly:
     data:
       CentOS Linux-7:
-      - etc/cron.hourly:
+      - /etc/cron.hourly:
           gid: 0
           group: root
           mode: 700

--- a/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-1-0.yaml
@@ -140,7 +140,7 @@ grep:
             pattern: ^inet_interfaces
             match_output: localhost
             tag: CIS-2.2.15
-      description: Ensure mail transfer agent is configured for local-only mode 
+      description: Ensure mail transfer agent is configured for local-only mode
     default_umask:
       data:
         CentOS Linux-7:
@@ -161,7 +161,7 @@ grep:
         - /etc/modprobe.d:
             match_output: /bin/true
             pattern: cramfs
-            grep_args: 
+            grep_args:
               - '-r'
             tag: CIS-1.1.1.1
       description: Ensure mounting of cramfs filesystems is disabled
@@ -866,7 +866,7 @@ stat:
   cron_hourly:
     data:
       CentOS Linux-7:
-      - etc/cron.hourly:
+      - /etc/cron.hourly:
           gid: 0
           group: root
           mode: 700

--- a/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2.yaml
+++ b/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2.yaml
@@ -140,7 +140,7 @@ grep:
             pattern: ^inet_interfaces
             match_output: localhost
             tag: CIS-2.2.15
-      description: Ensure mail transfer Agent is configured for local-only (Scored) 
+      description: Ensure mail transfer Agent is configured for local-only (Scored)
     default_umask:
       data:
         CentOS Linux-7:
@@ -161,7 +161,7 @@ grep:
         - /etc/modprobe.d:
             match_output: /bin/true
             pattern: cramfs
-            grep_args: 
+            grep_args:
               - '-r'
             tag: CIS-1.1.1.1
       description: Disable mounting cramfs filesystems (Scored).
@@ -328,7 +328,7 @@ grep:
             pattern: lo
             match_output: ACCEPT
             tag: CIS-3.6.3
-      description: Ensure loopback traffic is configured (Scored) 
+      description: Ensure loopback traffic is configured (Scored)
     rsyslog_file_perms:
       data:
         CentOS Linux-7:
@@ -846,7 +846,7 @@ stat:
   cron_hourly:
     data:
       CentOS Linux-7:
-      - etc/cron.hourly:
+      - /etc/cron.hourly:
           gid: 0
           group: root
           mode: 700

--- a/hubblestack_nova_profiles/cis/debian-8-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/debian-8-level-1-scored-v1-0-0.yaml
@@ -366,7 +366,7 @@ stat:
   cron_hourly:
     data:
       Debian-8:
-        - 'etc/cron.hourly':
+        - '/etc/cron.hourly':
             tag: 'CIS-9.1.3'
             mode: 700
             user: 'root'

--- a/hubblestack_nova_profiles/cis/debian-8-level-1-scored-v1.yaml
+++ b/hubblestack_nova_profiles/cis/debian-8-level-1-scored-v1.yaml
@@ -366,7 +366,7 @@ stat:
   cron_hourly:
     data:
       Debian-8:
-        - 'etc/cron.hourly':
+        - '/etc/cron.hourly':
             tag: 'CIS-9.1.3'
             mode: 700
             user: 'root'

--- a/hubblestack_nova_profiles/cis/rhels-6-level-1-scored-v1.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-6-level-1-scored-v1.yaml
@@ -559,7 +559,7 @@ stat:
   cron_hourly:
     data:
       Red Hat Enterprise Linux Server-6:
-      - etc/cron.hourly:
+      - /etc/cron.hourly:
           gid: 0
           group: root
           mode: 700

--- a/hubblestack_nova_profiles/cis/rhels-6-level-1-scored-v2-0-1.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-6-level-1-scored-v2-0-1.yaml
@@ -491,7 +491,7 @@ service:
       data:
         Red Hat Enterprise Linux Server-6:
         - iptables: CIS-4.7_running
-      description: 
+      description:
     rsyslogd_running:
       data:
         Red Hat Enterprise Linux Server-6:
@@ -578,7 +578,7 @@ stat:
   cron_hourly:
     data:
       Red Hat Enterprise Linux Server-6:
-      - etc/cron.hourly:
+      - /etc/cron.hourly:
           gid: 0
           group: root
           mode: 700

--- a/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v1.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v1.yaml
@@ -140,7 +140,7 @@ grep:
             pattern: ^inet_interfaces
             match_output: localhost
             tag: CIS-2.2.15
-      description: Ensure mail transfer Agent is configured for local-only (Scored) 
+      description: Ensure mail transfer Agent is configured for local-only (Scored)
     default_umask:
       data:
         Red Hat Enterprise Linux Server-7:
@@ -161,7 +161,7 @@ grep:
         - /etc/modprobe.d:
             match_output: /bin/true
             pattern: cramfs
-            grep_args: 
+            grep_args:
               - '-r'
             tag: CIS-1.1.1.1
       description: Disable mounting cramfs filesystems (Scored).
@@ -328,7 +328,7 @@ grep:
             pattern: lo
             match_output: ACCEPT
             tag: CIS-3.6.3
-      description: Ensure loopback traffic is configured (Scored) 
+      description: Ensure loopback traffic is configured (Scored)
     rsyslog_file_perms:
       data:
         Red Hat Enterprise Linux Server-7:
@@ -846,7 +846,7 @@ stat:
   cron_hourly:
     data:
       Red Hat Enterprise Linux Server-7:
-      - etc/cron.hourly:
+      - /etc/cron.hourly:
           gid: 0
           group: root
           mode: 700

--- a/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v2-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v2-1-0.yaml
@@ -140,7 +140,7 @@ grep:
             pattern: ^inet_interfaces
             match_output: localhost
             tag: CIS-2.2.15
-      description: Ensure mail transfer agent is configured for local-only mode 
+      description: Ensure mail transfer agent is configured for local-only mode
     default_umask:
       data:
         Red Hat Enterprise Linux Server-7:
@@ -161,7 +161,7 @@ grep:
         - /etc/modprobe.d:
             match_output: /bin/true
             pattern: cramfs
-            grep_args: 
+            grep_args:
               - '-r'
             tag: CIS-1.1.1.1
       description: Ensure mounting of cramfs filesystems is disabled
@@ -866,7 +866,7 @@ stat:
   cron_hourly:
     data:
       Red Hat Enterprise Linux Server-7:
-      - etc/cron.hourly:
+      - /etc/cron.hourly:
           gid: 0
           group: root
           mode: 700

--- a/hubblestack_nova_profiles/cis/rhelw-7-level-1-scored-v1.yaml
+++ b/hubblestack_nova_profiles/cis/rhelw-7-level-1-scored-v1.yaml
@@ -140,7 +140,7 @@ grep:
             pattern: ^inet_interfaces
             match_output: localhost
             tag: CIS-2.2.15
-      description: Ensure mail transfer Agent is configured for local-only (Scored) 
+      description: Ensure mail transfer Agent is configured for local-only (Scored)
     default_umask:
       data:
         Red Hat Enterprise Linux Workstation-7:
@@ -161,7 +161,7 @@ grep:
         - /etc/modprobe.d:
             match_output: /bin/true
             pattern: cramfs
-            grep_args: 
+            grep_args:
               - '-r'
             tag: CIS-1.1.1.1
       description: Disable mounting cramfs filesystems (Scored).
@@ -318,7 +318,7 @@ grep:
             pattern: lo
             match_output: ACCEPT
             tag: CIS-3.6.3
-      description: Ensure loopback traffic is configured (Scored) 
+      description: Ensure loopback traffic is configured (Scored)
     rsyslog_file_perms:
       data:
         Red Hat Enterprise Linux Workstation-7:
@@ -826,7 +826,7 @@ stat:
   cron_hourly:
     data:
       Red Hat Enterprise Linux Workstation-7:
-      - etc/cron.hourly:
+      - /etc/cron.hourly:
           gid: 0
           group: root
           mode: 700

--- a/hubblestack_nova_profiles/cis/rhelw-7-level-1-scored-v2-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhelw-7-level-1-scored-v2-1-0.yaml
@@ -140,7 +140,7 @@ grep:
             pattern: ^inet_interfaces
             match_output: localhost
             tag: CIS-2.2.15
-      description: Ensure mail transfer agent is configured for local-only mode 
+      description: Ensure mail transfer agent is configured for local-only mode
     default_umask:
       data:
         Red Hat Enterprise Linux Workstation-7:
@@ -161,7 +161,7 @@ grep:
         - /etc/modprobe.d:
             match_output: /bin/true
             pattern: cramfs
-            grep_args: 
+            grep_args:
               - '-r'
             tag: CIS-1.1.1.1
       description: Ensure mounting of cramfs filesystems is disabled
@@ -846,7 +846,7 @@ stat:
   cron_hourly:
     data:
       Red Hat Enterprise Linux Workstation-7:
-      - etc/cron.hourly:
+      - /etc/cron.hourly:
           gid: 0
           group: root
           mode: 700

--- a/hubblestack_nova_profiles/samples/sample_cis.yaml
+++ b/hubblestack_nova_profiles/samples/sample_cis.yaml
@@ -223,7 +223,7 @@ stat:
   cron_hourly:
     data:
       'Red Hat Enterprise Linux Server-6':
-        - 'etc/cron.hourly':
+        - '/etc/cron.hourly':
             tag: 'CIS-6.1.5'
             mode: 700
             user: 'root'
@@ -231,7 +231,7 @@ stat:
             group: 'root'
             gid: 0
       'CentOS Linux-7':
-        - 'etc/cron.hourly':
+        - '/etc/cron.hourly':
             tag: 'CIS-6.1.5'
             mode: 700
             user: 'root'


### PR DESCRIPTION
Several profile were missing a slash '/' at the beginning of /etc/cron.hourly, causing those checks to fail.
