### PR TITLE
Added value retrieved when in verbose mode

### DIFF
--- a/hubblestack_nova/win_reg.py
+++ b/hubblestack_nova/win_reg.py
@@ -82,9 +82,11 @@ def audit(data_list, tags, verbose=False, show_profile=False, debug=False):
                         if secret:
                             ret['Success'].append(tag_data)
                         else:
+                            tag_data['value_found'] = current
                             ret['Failure'].append(tag_data)
 
                     else:
+                        tag_data['value_found'] = None
                         ret['Failure'].append(tag_data)
 
 
@@ -211,7 +213,7 @@ def _get_tags(data):
                             ret[tag] = []
                         formatted_data = {'name': name,
                                           'tag': tag,
-                                          'module': 'win_auditpol',
+                                          'module': 'win_reg',
                                           'type': toplist}
                         formatted_data.update(tag_data)
                         formatted_data.update(audit_data)

--- a/hubblestack_nova_profiles/cis/windows-2012r2-level-1-scored-v2-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/windows-2012r2-level-1-scored-v2-0-0.yaml
@@ -1489,7 +1489,7 @@ win_reg:
         'Microsoft Windows Server 2012*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\Network Connections\NC_StdDomainUserSetLocation':
               tag: CIS-18.4.10.3
-              match_output: ' is set to '
+              match_output: 'Enabled'
               value_type: 'equal'
       description: (l1) ensure 'require domain users to elevate when setting a network's location' is set to 'enabled'
     Hardened UNC Paths :


### PR DESCRIPTION
This will give you the found_value in win_reg when running in verbose mode.  This will help debug problems when you think its the right value and it is still failing
