### PR TITLE
win_secedit win32 fixes

### DIFF
--- a/hubblestack_nova/win_secedit.py
+++ b/hubblestack_nova/win_secedit.py
@@ -264,11 +264,13 @@ def _secedit_import(inf_file):
 def _get_account_sid():
     '''This helper function will get all the users and groups on the computer
     and return a dictionary'''
-    win32 = __salt__['cmd.run']('Get-WmiObject win32_useraccount | Format-List -Property '
-                                'Name, SID', shell='powershell', python_shell=True)
+    win32 = __salt__['cmd.run']('Get-WmiObject win32_useraccount -Filter "localaccount=\'True\'"'
+                                ' | Format-List -Property Name, SID', shell='powershell', 
+                                python_shell=True)
     win32 += '\n'
-    win32 += __salt__['cmd.run']('Get-WmiObject win32_group | Format-List -Property Name, '
-                                 'SID', shell='powershell', python_shell=True)
+    win32 += __salt__['cmd.run']('Get-WmiObject win32_group -Filter "localaccount=\'True\'" | '
+                                 'Format-List -Property Name, SID', shell='powershell',
+                                 python_shell=True)
     if win32:
 
         dict_return = {}


### PR DESCRIPTION
Both win32_group and win32_useraccount would take upward of 5 minutes to complete on some systems, making it look like Nova was hanging.  I have modified both of these commands to only look at local accounts, and it has sped up the process considerably
