### PR TITLE
Fix windows 2008 nova cis issues

### DIFF
--- a/hubblestack_nova/win_secedit.py
+++ b/hubblestack_nova/win_secedit.py
@@ -280,7 +280,7 @@ def _get_account_sid():
             lines.remove('local:')
         for line in lines:
             line = line.strip()
-            if line != '':
+            if line != '' and ' : ' in line:
                 k, v = line.split(' : ')
                 if k.lower() == 'name':
                     key = v

--- a/hubblestack_nova_profiles/cis/windows-2008r2-level-1-scored-v1.yaml
+++ b/hubblestack_nova_profiles/cis/windows-2008r2-level-1-scored-v1.yaml
@@ -804,7 +804,7 @@ win_secedit:
               match_output: 'Enabled'
               value_type: 'equal'
       description: 'User Account Control Virtualize file and registry write failures to per-user locations'
-       
+
   blacklist:
     accounts_rename_administrator_account :
       data:
@@ -903,248 +903,248 @@ win_secedit:
               value_type: 'account'
       description: 'Synchronize directory service data'
 
-win_firewall:
-  whitelist:
-    windows_firewall_domain_firewall_state :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'Enabled':
-              tag: CIS-9.1.1
-              match_output: 'True'
-              value_type: 'domain'
-      description: 'Windows Firewall Domain Firewall state'
-    windows_firewall_domain_inbound_connections :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'DefaultInboundAction':
-              tag: CIS-9.1.2
-              match_output: 'Block'
-              value_type: 'domain'
-      description: 'Windows Firewall Domain Inbound connections'
-    windows_firewall_domain_outbound_connections :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'DefaultOutboundAction':
-              tag: CIS-9.1.3
-              match_output: 'Allow'
-              value_type: 'domain'
-      description: 'Windows Firewall Domain Outbound connections'
-    windows_firewall_domain_settings_display_a_notification :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'NotifyOnListen':
-              tag: CIS-9.1.4
-              match_output: 'False'
-              value_type: 'domain'
-      description: 'Windows Firewall Domain Settings Display a notification'
-    windows_firewall_domain_settings_apply_local_firewall_rules :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'AllowLocalFirewallRules':
-              tag: CIS-9.1.5
-              match_output: 'True'
-              value_type: 'domain'
-      description: 'Windows Firewall Domain Settings Apply local firewall rules'
-    windows_firewall_domain_settings_apply_local_connection_security_rules :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'AllowLocalIPsecRules':
-              tag: CIS-9.1.6
-              match_output: 'True'
-              value_type: 'domain'
-      description: 'Windows Firewall Domain Settings Apply local connection security rules'
-    windows_firewall_domain_logging_name :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'LogFileName':
-              tag: CIS-9.1.7
-              match_output: '%SYSTEMROOT%\System32\logfiles\firewall\domainfw.log'
-              value_type: 'domain'
-      description: 'Windows Firewall Domain Logging Name'
-    windows_firewall_domain_logging_size_limit :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'LogMaxSizeKilobytes':
-              tag: CIS-9.1.8
-              match_output: '16384'
-              value_type: 'domain'
-      description: 'Windows Firewall Domain Logging Size limit'
-    windows_firewall_domain_logging_log_dropped_packets :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'LogBlocked':
-              tag: CIS-9.1.9
-              match_output: 'True'
-              value_type: 'domain'
-      description: 'Windows Firewall Domain Logging Log dropped packets'
-    windows_firewall_domain_logging_log_successful_connections :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'LogAllowed':
-              tag: CIS-9.1.10
-              match_output: 'True'
-              value_type: 'domain'
-      description: 'Windows Firewall Domain Logging Log successful connections'
-    windows_firewall_private_firewall_state :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'Enabled':
-              tag: CIS-9.2.1
-              match_output: 'True'
-              value_type: 'private'
-      description: 'Windows Firewall Private Firewall state'
-    windows_firewall_private_inbound_connections :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'DefaultInboundAction':
-              tag: CIS-9.2.2
-              match_output: 'Block'
-              value_type: 'private'
-      description: 'Windows Firewall Private Inbound connections'
-    windows_firewall_private_outbound_connections :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'DefaultOutboundAction':
-              tag: CIS-9.2.3
-              match_output: 'Allow'
-              value_type: 'private'
-      description: 'Windows Firewall Private Outbound connections'
-    windows_firewall_private_settings_display_a_notification :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'NotifyOnListen':
-              tag: CIS-9.2.4
-              match_output: 'False'
-              value_type: 'private'
-      description: 'Windows Firewall Private Settings Display a notification'
-    windows_firewall_private_settings_apply_local_firewall_rules :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'AllowLocalFirewallRules':
-              tag: CIS-9.2.5
-              match_output: 'True'
-              value_type: 'private'
-      description: 'Windows Firewall Private Settings Apply local firewall rules'
-    windows_firewall_private_settings_apply_local_connection_security_rules :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'AllowLocalIPsecRules':
-              tag: CIS-9.2.6
-              match_output: 'True'
-              value_type: 'private'
-      description: 'Windows Firewall Private Settings Apply local connection security rules'
-    windows_firewall_private_logging_name :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'LogFileName':
-              tag: CIS-9.2.7
-              match_output: '%SYSTEMROOT%\System32\logfiles\firewall\privatefw.log'
-              value_type: 'private'
-      description: 'Windows Firewall Private Logging Name'
-    windows_firewall_private_logging_size_limit :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'LogMaxSizeKilobytes':
-              tag: CIS-9.2.8
-              match_output: '16384'
-              value_type: 'private'
-      description: 'Windows Firewall Private Logging Size limit'
-    windows_firewall_private_logging_log_dropped_packets :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'LogBlocked':
-              tag: CIS-9.2.9
-              match_output: 'True'
-              value_type: 'private'
-      description: 'Windows Firewall Private Logging Log dropped packets'
-    windows_firewall_private_logging_log_successful_connections :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'LogAllowed':
-              tag: CIS-9.2.10
-              match_output: 'True'
-              value_type: 'private'
-      description: 'Windows Firewall Private Logging Log successful connections'
-    windows_firewall_public_firewall_state :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'Enabled':
-              tag: CIS-9.3.1
-              match_output: 'True'
-              value_type: 'public'
-      description: 'Windows Firewall Public Firewall state'
-    windows_firewall_public_inbound_connections :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'DefaultInboundAction':
-              tag: CIS-9.3.2
-              match_output: 'Block'
-              value_type: 'public'
-      description: 'Windows Firewall Public Inbound connections'
-    windows_firewall_public_outbound_connections :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'DefaultOutboundAction':
-              tag: CIS-9.3.3
-              match_output: 'Allow'
-              value_type: 'public'
-      description: 'Windows Firewall Public Outbound connections'
-    windows_firewall_public_settings_display_a_notification :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'NotifyOnListen':
-              tag: CIS-9.3.4
-              match_output: 'True'
-              value_type: 'public'
-      description: 'Windows Firewall Public Settings Display a notification'
-    windows_firewall_public_settings_apply_local_firewall_rules :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'AllowLocalFirewallRules':
-              tag: CIS-9.3.5
-              match_output: 'False'
-              value_type: 'public'
-      description: 'Windows Firewall Public Settings Apply local firewall rules'
-    windows_firewall_public_settings_apply_local_connection_security_rules :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'AllowLocalIPsecRules':
-              tag: CIS-9.3.6
-              match_output: 'False'
-              value_type: 'public'
-      description: 'Windows Firewall Public Settings Apply local connection security rules'
-    windows_firewall_public_logging_name :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'LogFileName':
-              tag: CIS-9.3.7
-              match_output: '%SYSTEMROOT%\System32\logfiles\firewall\publicfw.log'
-              value_type: 'public'
-      description: 'Windows Firewall Public Logging Name'
-    windows_firewall_public_logging_size_limit_(kb :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'LogMaxSizeKilobytes':
-              tag: CIS-9.3.8
-              match_output: '16384'
-              value_type: 'public'
-      description: 'Windows Firewall Public Logging Size limit'
-    windows_firewall_public_logging_log_dropped_packets :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'LogBlocked':
-              tag: CIS-9.3.9
-              match_output: 'True'
-              value_type: 'public'
-      description: 'Windows Firewall Public Logging Log dropped packets'
-    windows_firewall_public_logging_log_successful_connections :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'LogAllowed':
-              tag: CIS-9.3.10
-              match_output: 'True'
-              value_type: 'public'
-      description: 'Windows Firewall Public Logging Log successful connections'
+#win_firewall:
+#  whitelist:
+#    windows_firewall_domain_firewall_state :
+#      data:
+#        'Microsoft Windows Server 2008*':
+#          - 'Enabled':
+#              tag: CIS-9.1.1
+#              match_output: 'True'
+#              value_type: 'domain'
+#      description: 'Windows Firewall Domain Firewall state'
+#    windows_firewall_domain_inbound_connections :
+#      data:
+#        'Microsoft Windows Server 2008*':
+#          - 'DefaultInboundAction':
+#              tag: CIS-9.1.2
+#              match_output: 'Block'
+#              value_type: 'domain'
+#      description: 'Windows Firewall Domain Inbound connections'
+#    windows_firewall_domain_outbound_connections :
+#      data:
+#        'Microsoft Windows Server 2008*':
+#          - 'DefaultOutboundAction':
+#              tag: CIS-9.1.3
+#              match_output: 'Allow'
+#              value_type: 'domain'
+#      description: 'Windows Firewall Domain Outbound connections'
+#    windows_firewall_domain_settings_display_a_notification :
+#      data:
+#        'Microsoft Windows Server 2008*':
+#          - 'NotifyOnListen':
+#              tag: CIS-9.1.4
+#              match_output: 'False'
+#              value_type: 'domain'
+#      description: 'Windows Firewall Domain Settings Display a notification'
+#    windows_firewall_domain_settings_apply_local_firewall_rules :
+#      data:
+#        'Microsoft Windows Server 2008*':
+#          - 'AllowLocalFirewallRules':
+#              tag: CIS-9.1.5
+#              match_output: 'True'
+#              value_type: 'domain'
+#      description: 'Windows Firewall Domain Settings Apply local firewall rules'
+#    windows_firewall_domain_settings_apply_local_connection_security_rules :
+#      data:
+#        'Microsoft Windows Server 2008*':
+#          - 'AllowLocalIPsecRules':
+#              tag: CIS-9.1.6
+#              match_output: 'True'
+#              value_type: 'domain'
+#      description: 'Windows Firewall Domain Settings Apply local connection security rules'
+#    windows_firewall_domain_logging_name :
+#      data:
+#        'Microsoft Windows Server 2008*':
+#          - 'LogFileName':
+#              tag: CIS-9.1.7
+#              match_output: '%SYSTEMROOT%\System32\logfiles\firewall\domainfw.log'
+#              value_type: 'domain'
+#      description: 'Windows Firewall Domain Logging Name'
+#    windows_firewall_domain_logging_size_limit :
+#      data:
+#        'Microsoft Windows Server 2008*':
+#          - 'LogMaxSizeKilobytes':
+#              tag: CIS-9.1.8
+#              match_output: '16384'
+#              value_type: 'domain'
+#      description: 'Windows Firewall Domain Logging Size limit'
+#    windows_firewall_domain_logging_log_dropped_packets :
+#      data:
+#        'Microsoft Windows Server 2008*':
+#          - 'LogBlocked':
+#              tag: CIS-9.1.9
+#              match_output: 'True'
+#              value_type: 'domain'
+#      description: 'Windows Firewall Domain Logging Log dropped packets'
+#    windows_firewall_domain_logging_log_successful_connections :
+#      data:
+#        'Microsoft Windows Server 2008*':
+#          - 'LogAllowed':
+#              tag: CIS-9.1.10
+#              match_output: 'True'
+#              value_type: 'domain'
+#      description: 'Windows Firewall Domain Logging Log successful connections'
+#    windows_firewall_private_firewall_state :
+#      data:
+#        'Microsoft Windows Server 2008*':
+#          - 'Enabled':
+#              tag: CIS-9.2.1
+#              match_output: 'True'
+#              value_type: 'private'
+#      description: 'Windows Firewall Private Firewall state'
+#    windows_firewall_private_inbound_connections :
+#      data:
+#        'Microsoft Windows Server 2008*':
+#          - 'DefaultInboundAction':
+#              tag: CIS-9.2.2
+#              match_output: 'Block'
+#              value_type: 'private'
+#      description: 'Windows Firewall Private Inbound connections'
+#    windows_firewall_private_outbound_connections :
+#      data:
+#        'Microsoft Windows Server 2008*':
+#          - 'DefaultOutboundAction':
+#              tag: CIS-9.2.3
+#              match_output: 'Allow'
+#              value_type: 'private'
+#      description: 'Windows Firewall Private Outbound connections'
+#    windows_firewall_private_settings_display_a_notification :
+#      data:
+#        'Microsoft Windows Server 2008*':
+#          - 'NotifyOnListen':
+#              tag: CIS-9.2.4
+#              match_output: 'False'
+#              value_type: 'private'
+#      description: 'Windows Firewall Private Settings Display a notification'
+#    windows_firewall_private_settings_apply_local_firewall_rules :
+#      data:
+#        'Microsoft Windows Server 2008*':
+#          - 'AllowLocalFirewallRules':
+#              tag: CIS-9.2.5
+#              match_output: 'True'
+#              value_type: 'private'
+#      description: 'Windows Firewall Private Settings Apply local firewall rules'
+#    windows_firewall_private_settings_apply_local_connection_security_rules :
+#      data:
+#        'Microsoft Windows Server 2008*':
+#          - 'AllowLocalIPsecRules':
+#              tag: CIS-9.2.6
+#              match_output: 'True'
+#              value_type: 'private'
+#      description: 'Windows Firewall Private Settings Apply local connection security rules'
+#    windows_firewall_private_logging_name :
+#      data:
+#        'Microsoft Windows Server 2008*':
+#          - 'LogFileName':
+#              tag: CIS-9.2.7
+#              match_output: '%SYSTEMROOT%\System32\logfiles\firewall\privatefw.log'
+#              value_type: 'private'
+#      description: 'Windows Firewall Private Logging Name'
+#    windows_firewall_private_logging_size_limit :
+#      data:
+#        'Microsoft Windows Server 2008*':
+#          - 'LogMaxSizeKilobytes':
+#              tag: CIS-9.2.8
+#              match_output: '16384'
+#              value_type: 'private'
+#      description: 'Windows Firewall Private Logging Size limit'
+#    windows_firewall_private_logging_log_dropped_packets :
+#      data:
+#        'Microsoft Windows Server 2008*':
+#          - 'LogBlocked':
+#              tag: CIS-9.2.9
+#              match_output: 'True'
+#              value_type: 'private'
+#      description: 'Windows Firewall Private Logging Log dropped packets'
+#    windows_firewall_private_logging_log_successful_connections :
+#      data:
+#        'Microsoft Windows Server 2008*':
+#          - 'LogAllowed':
+#              tag: CIS-9.2.10
+#              match_output: 'True'
+#              value_type: 'private'
+#      description: 'Windows Firewall Private Logging Log successful connections'
+#    windows_firewall_public_firewall_state :
+#      data:
+#        'Microsoft Windows Server 2008*':
+#          - 'Enabled':
+#              tag: CIS-9.3.1
+#              match_output: 'True'
+#              value_type: 'public'
+#      description: 'Windows Firewall Public Firewall state'
+#    windows_firewall_public_inbound_connections :
+#      data:
+#        'Microsoft Windows Server 2008*':
+#          - 'DefaultInboundAction':
+#              tag: CIS-9.3.2
+#              match_output: 'Block'
+#              value_type: 'public'
+#      description: 'Windows Firewall Public Inbound connections'
+#    windows_firewall_public_outbound_connections :
+#      data:
+#        'Microsoft Windows Server 2008*':
+#          - 'DefaultOutboundAction':
+#              tag: CIS-9.3.3
+#              match_output: 'Allow'
+#              value_type: 'public'
+#      description: 'Windows Firewall Public Outbound connections'
+#    windows_firewall_public_settings_display_a_notification :
+#      data:
+#        'Microsoft Windows Server 2008*':
+#          - 'NotifyOnListen':
+#              tag: CIS-9.3.4
+#              match_output: 'True'
+#              value_type: 'public'
+#      description: 'Windows Firewall Public Settings Display a notification'
+#    windows_firewall_public_settings_apply_local_firewall_rules :
+#      data:
+#        'Microsoft Windows Server 2008*':
+#          - 'AllowLocalFirewallRules':
+#              tag: CIS-9.3.5
+#              match_output: 'False'
+#              value_type: 'public'
+#      description: 'Windows Firewall Public Settings Apply local firewall rules'
+#    windows_firewall_public_settings_apply_local_connection_security_rules :
+#      data:
+#        'Microsoft Windows Server 2008*':
+#          - 'AllowLocalIPsecRules':
+#              tag: CIS-9.3.6
+#              match_output: 'False'
+#              value_type: 'public'
+#      description: 'Windows Firewall Public Settings Apply local connection security rules'
+#    windows_firewall_public_logging_name :
+#      data:
+#        'Microsoft Windows Server 2008*':
+#          - 'LogFileName':
+#              tag: CIS-9.3.7
+#              match_output: '%SYSTEMROOT%\System32\logfiles\firewall\publicfw.log'
+#              value_type: 'public'
+#      description: 'Windows Firewall Public Logging Name'
+#    windows_firewall_public_logging_size_limit_(kb :
+#      data:
+#        'Microsoft Windows Server 2008*':
+#          - 'LogMaxSizeKilobytes':
+#              tag: CIS-9.3.8
+#              match_output: '16384'
+#              value_type: 'public'
+#      description: 'Windows Firewall Public Logging Size limit'
+#    windows_firewall_public_logging_log_dropped_packets :
+#      data:
+#        'Microsoft Windows Server 2008*':
+#          - 'LogBlocked':
+#              tag: CIS-9.3.9
+#              match_output: 'True'
+#              value_type: 'public'
+#      description: 'Windows Firewall Public Logging Log dropped packets'
+#    windows_firewall_public_logging_log_successful_connections :
+#      data:
+#        'Microsoft Windows Server 2008*':
+#          - 'LogAllowed':
+#              tag: CIS-9.3.10
+#              match_output: 'True'
+#              value_type: 'public'
+#      description: 'Windows Firewall Public Logging Log successful connections'
 
 win_auditpol:
   whitelist:

--- a/hubblestack_nova_profiles/cis/windows-2008r2-level-1-scored-v3-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/windows-2008r2-level-1-scored-v3-0-0.yaml
@@ -903,248 +903,248 @@ win_secedit:
               value_type: 'account'
       description: (l1) ensure 'synchronize directory service data' is set to 'no one' (dc only)
 
-win_firewall:
-  whitelist:
-    windows_firewall_domain_firewall_state :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'Enabled':
-              tag: CIS-9.1.1
-              match_output: 'True'
-              value_type: 'domain'
-      description: (l1) ensure 'windows firewall - domain - firewall state' is set to 'on (recommended)'
-    windows_firewall_domain_inbound_connections :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'DefaultInboundAction':
-              tag: CIS-9.1.2
-              match_output: 'Block'
-              value_type: 'domain'
-      description: (l1) ensure 'windows firewall - domain - inbound connections' is set to 'block (default)'
-    windows_firewall_domain_outbound_connections :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'DefaultOutboundAction':
-              tag: CIS-9.1.3
-              match_output: 'Allow'
-              value_type: 'domain'
-      description: (l1) ensure 'windows firewall - domain - outbound connections' is set to 'allow (default)'
-    windows_firewall_domain_settings_display_a_notification :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'NotifyOnListen':
-              tag: CIS-9.1.4
-              match_output: 'False'
-              value_type: 'domain'
-      description: (l1) ensure 'windows firewall - domain - settings - display a notification' is set to 'no'
-    windows_firewall_domain_settings_apply_local_firewall_rules :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'AllowLocalFirewallRules':
-              tag: CIS-9.1.5
-              match_output: 'True'
-              value_type: 'domain'
-      description: (l1) ensure 'windows firewall - domain - settings - apply local firewall rules' is set to 'yes (default)'
-    windows_firewall_domain_settings_apply_local_connection_security_rules :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'AllowLocalIPsecRules':
-              tag: CIS-9.1.6
-              match_output: 'True'
-              value_type: 'domain'
-      description: (l1) ensure 'windows firewall - domain - settings - apply local connection security rules' is set to 'yes (default)'
-    windows_firewall_domain_logging_name :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'LogFileName':
-              tag: CIS-9.1.7
-              match_output: '%SYSTEMROOT%\System32\logfiles\firewall\domainfw.log'
-              value_type: 'domain'
-      description: (l1) ensure 'windows firewall - domain - logging - name' is set to '%systemroot%\system32\logfiles\firewall\domainfw.log'
-    windows_firewall_domain_logging_size_limit :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'LogMaxSizeKilobytes':
-              tag: CIS-9.1.8
-              match_output: '16384'
-              value_type: 'domain'
-      description: (l1) ensure 'windows firewall - domain - logging - size limit (kb)' is set to '16,384 kb or greater'
-    windows_firewall_domain_logging_log_dropped_packets :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'LogBlocked':
-              tag: CIS-9.1.9
-              match_output: 'True'
-              value_type: 'domain'
-      description: (l1) ensure 'windows firewall - domain - logging - log dropped packets' is set to 'yes'
-    windows_firewall_domain_logging_log_successful_connections :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'LogAllowed':
-              tag: CIS-9.1.10
-              match_output: 'True'
-              value_type: 'domain'
-      description: (l1) ensure 'windows firewall - domain - logging - log successful connections' is set to 'yes'
-    windows_firewall_private_firewall_state :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'Enabled':
-              tag: CIS-9.2.1
-              match_output: 'True'
-              value_type: 'private'
-      description: (l1) ensure 'windows firewall - private - firewall state' is set to 'on (recommended)'
-    windows_firewall_private_inbound_connections :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'DefaultInboundAction':
-              tag: CIS-9.2.2
-              match_output: 'Block'
-              value_type: 'private'
-      description: (l1) ensure 'windows firewall - private - inbound connections' is set to 'block (default)'
-    windows_firewall_private_outbound_connections :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'DefaultOutboundAction':
-              tag: CIS-9.2.3
-              match_output: 'Allow'
-              value_type: 'private'
-      description: (l1) ensure 'windows firewall - private - outbound connections' is set to 'allow (default)'
-    windows_firewall_private_settings_display_a_notification :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'NotifyOnListen':
-              tag: CIS-9.2.4
-              match_output: 'False'
-              value_type: 'private'
-      description: (l1) ensure 'windows firewall - private - settings - display a notification' is set to 'no'
-    windows_firewall_private_settings_apply_local_firewall_rules :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'AllowLocalFirewallRules':
-              tag: CIS-9.2.5
-              match_output: 'True'
-              value_type: 'private'
-      description: (l1) ensure 'windows firewall - private - settings - apply local firewall rules' is set to 'yes (default)'
-    windows_firewall_private_settings_apply_local_connection_security_rules :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'AllowLocalIPsecRules':
-              tag: CIS-9.2.6
-              match_output: 'True'
-              value_type: 'private'
-      description: (l1) ensure 'windows firewall - private - settings - apply local connection security rules' is set to 'yes (default)'
-    windows_firewall_private_logging_name :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'LogFileName':
-              tag: CIS-9.2.7
-              match_output: '%SYSTEMROOT%\System32\logfiles\firewall\privatefw.log'
-              value_type: 'private'
-      description: (l1) ensure 'windows firewall - private - logging - name' is set to '%systemroot%\system32\logfiles\firewall\privatefw.log'
-    windows_firewall_private_logging_size_limit :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'LogMaxSizeKilobytes':
-              tag: CIS-9.2.8
-              match_output: '16384'
-              value_type: 'private'
-      description: (l1) ensure 'windows firewall - private - logging - size limit (kb)' is set to '16,384 kb or greater'
-    windows_firewall_private_logging_log_dropped_packets :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'LogBlocked':
-              tag: CIS-9.2.9
-              match_output: 'True'
-              value_type: 'private'
-      description: (l1) ensure 'windows firewall - private - logging - log dropped packets' is set to 'yes'
-    windows_firewall_private_logging_log_successful_connections :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'LogAllowed':
-              tag: CIS-9.2.10
-              match_output: 'True'
-              value_type: 'private'
-      description: (l1) ensure 'windows firewall - private - logging - log successful connections' is set to 'yes'
-    windows_firewall_public_firewall_state :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'Enabled':
-              tag: CIS-9.3.1
-              match_output: 'True'
-              value_type: 'public'
-      description: (l1) ensure 'windows firewall - public - firewall state' is set to 'on (recommended)'
-    windows_firewall_public_inbound_connections :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'DefaultInboundAction':
-              tag: CIS-9.3.2
-              match_output: 'Block'
-              value_type: 'public'
-      description: (l1) ensure 'windows firewall - public - inbound connections' is set to 'block (default)'
-    windows_firewall_public_outbound_connections :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'DefaultOutboundAction':
-              tag: CIS-9.3.3
-              match_output: 'Allow'
-              value_type: 'public'
-      description: (l1) ensure 'windows firewall - public - outbound connections' is set to 'allow (default)'
-    windows_firewall_public_settings_display_a_notification :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'NotifyOnListen':
-              tag: CIS-9.3.4
-              match_output: 'True'
-              value_type: 'public'
-      description: (l1) ensure 'windows firewall - public - settings - display a notification' is set to 'yes'
-    windows_firewall_public_settings_apply_local_firewall_rules :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'AllowLocalFirewallRules':
-              tag: CIS-9.3.5
-              match_output: 'False'
-              value_type: 'public'
-      description: (l1) ensure 'windows firewall - public - settings - apply local firewall rules' is set to 'no'
-    windows_firewall_public_settings_apply_local_connection_security_rules :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'AllowLocalIPsecRules':
-              tag: CIS-9.3.6
-              match_output: 'False'
-              value_type: 'public'
-      description: (l1) ensure 'windows firewall - public - settings - apply local connection security rules' is set to 'no'
-    windows_firewall_public_logging_name :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'LogFileName':
-              tag: CIS-9.3.7
-              match_output: '%SYSTEMROOT%\System32\logfiles\firewall\publicfw.log'
-              value_type: 'public'
-      description: (l1) ensure 'windows firewall - public - logging - name' is set to '%systemroot%\system32\logfiles\firewall\publicfw.log'
-    windows_firewall_public_logging_size_limit_(kb :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'LogMaxSizeKilobytes':
-              tag: CIS-9.3.8
-              match_output: '16384'
-              value_type: 'public'
-      description: (l1) ensure 'windows firewall - public - logging - size limit (kb)' is set to '16,384 kb or greater'
-    windows_firewall_public_logging_log_dropped_packets :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'LogBlocked':
-              tag: CIS-9.3.9
-              match_output: 'True'
-              value_type: 'public'
-      description: (l1) ensure 'windows firewall - public - logging - log dropped packets' is set to 'yes'
-    windows_firewall_public_logging_log_successful_connections :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'LogAllowed':
-              tag: CIS-9.3.10
-              match_output: 'True'
-              value_type: 'public'
-      description: (l1) ensure 'windows firewall - public - logging - log successful connections' is set to 'yes'
+#win_firewall:
+#  whitelist:
+#    windows_firewall_domain_firewall_state :
+#      data:
+#        'Microsoft Windows Server 2008*':
+#          - 'Enabled':
+#              tag: CIS-9.1.1
+#              match_output: 'True'
+#              value_type: 'domain'
+#      description: (l1) ensure 'windows firewall - domain - firewall state' is set to 'on (recommended)'
+#    windows_firewall_domain_inbound_connections :
+#      data:
+#        'Microsoft Windows Server 2008*':
+#          - 'DefaultInboundAction':
+#              tag: CIS-9.1.2
+#              match_output: 'Block'
+#              value_type: 'domain'
+#      description: (l1) ensure 'windows firewall - domain - inbound connections' is set to 'block (default)'
+#    windows_firewall_domain_outbound_connections :
+#      data:
+#        'Microsoft Windows Server 2008*':
+#          - 'DefaultOutboundAction':
+#              tag: CIS-9.1.3
+#              match_output: 'Allow'
+#              value_type: 'domain'
+#      description: (l1) ensure 'windows firewall - domain - outbound connections' is set to 'allow (default)'
+#    windows_firewall_domain_settings_display_a_notification :
+#      data:
+#        'Microsoft Windows Server 2008*':
+#          - 'NotifyOnListen':
+#              tag: CIS-9.1.4
+#              match_output: 'False'
+#              value_type: 'domain'
+#      description: (l1) ensure 'windows firewall - domain - settings - display a notification' is set to 'no'
+#    windows_firewall_domain_settings_apply_local_firewall_rules :
+#      data:
+#        'Microsoft Windows Server 2008*':
+#          - 'AllowLocalFirewallRules':
+#              tag: CIS-9.1.5
+#              match_output: 'True'
+#              value_type: 'domain'
+#      description: (l1) ensure 'windows firewall - domain - settings - apply local firewall rules' is set to 'yes (default)'
+#    windows_firewall_domain_settings_apply_local_connection_security_rules :
+#      data:
+#        'Microsoft Windows Server 2008*':
+#          - 'AllowLocalIPsecRules':
+#              tag: CIS-9.1.6
+#              match_output: 'True'
+#              value_type: 'domain'
+#      description: (l1) ensure 'windows firewall - domain - settings - apply local connection security rules' is set to 'yes (default)'
+#    windows_firewall_domain_logging_name :
+#      data:
+#        'Microsoft Windows Server 2008*':
+#          - 'LogFileName':
+#              tag: CIS-9.1.7
+#              match_output: '%SYSTEMROOT%\System32\logfiles\firewall\domainfw.log'
+#              value_type: 'domain'
+#      description: (l1) ensure 'windows firewall - domain - logging - name' is set to '%systemroot%\system32\logfiles\firewall\domainfw.log'
+#    windows_firewall_domain_logging_size_limit :
+#      data:
+#        'Microsoft Windows Server 2008*':
+#          - 'LogMaxSizeKilobytes':
+#              tag: CIS-9.1.8
+#              match_output: '16384'
+#              value_type: 'domain'
+#      description: (l1) ensure 'windows firewall - domain - logging - size limit (kb)' is set to '16,384 kb or greater'
+#    windows_firewall_domain_logging_log_dropped_packets :
+#      data:
+#        'Microsoft Windows Server 2008*':
+#          - 'LogBlocked':
+#              tag: CIS-9.1.9
+#              match_output: 'True'
+#              value_type: 'domain'
+#      description: (l1) ensure 'windows firewall - domain - logging - log dropped packets' is set to 'yes'
+#    windows_firewall_domain_logging_log_successful_connections :
+#      data:
+#        'Microsoft Windows Server 2008*':
+#          - 'LogAllowed':
+#              tag: CIS-9.1.10
+#              match_output: 'True'
+#              value_type: 'domain'
+#      description: (l1) ensure 'windows firewall - domain - logging - log successful connections' is set to 'yes'
+#    windows_firewall_private_firewall_state :
+#      data:
+#        'Microsoft Windows Server 2008*':
+#          - 'Enabled':
+#              tag: CIS-9.2.1
+#              match_output: 'True'
+#              value_type: 'private'
+#      description: (l1) ensure 'windows firewall - private - firewall state' is set to 'on (recommended)'
+#    windows_firewall_private_inbound_connections :
+#      data:
+#        'Microsoft Windows Server 2008*':
+#          - 'DefaultInboundAction':
+#              tag: CIS-9.2.2
+#              match_output: 'Block'
+#              value_type: 'private'
+#      description: (l1) ensure 'windows firewall - private - inbound connections' is set to 'block (default)'
+#    windows_firewall_private_outbound_connections :
+#      data:
+#        'Microsoft Windows Server 2008*':
+#          - 'DefaultOutboundAction':
+#              tag: CIS-9.2.3
+#              match_output: 'Allow'
+#              value_type: 'private'
+#      description: (l1) ensure 'windows firewall - private - outbound connections' is set to 'allow (default)'
+#    windows_firewall_private_settings_display_a_notification :
+#      data:
+#        'Microsoft Windows Server 2008*':
+#          - 'NotifyOnListen':
+#              tag: CIS-9.2.4
+#              match_output: 'False'
+#              value_type: 'private'
+#      description: (l1) ensure 'windows firewall - private - settings - display a notification' is set to 'no'
+#    windows_firewall_private_settings_apply_local_firewall_rules :
+#      data:
+#        'Microsoft Windows Server 2008*':
+#          - 'AllowLocalFirewallRules':
+#              tag: CIS-9.2.5
+#              match_output: 'True'
+#              value_type: 'private'
+#      description: (l1) ensure 'windows firewall - private - settings - apply local firewall rules' is set to 'yes (default)'
+#    windows_firewall_private_settings_apply_local_connection_security_rules :
+#      data:
+#        'Microsoft Windows Server 2008*':
+#          - 'AllowLocalIPsecRules':
+#              tag: CIS-9.2.6
+#              match_output: 'True'
+#              value_type: 'private'
+#      description: (l1) ensure 'windows firewall - private - settings - apply local connection security rules' is set to 'yes (default)'
+#    windows_firewall_private_logging_name :
+#      data:
+#        'Microsoft Windows Server 2008*':
+#          - 'LogFileName':
+#              tag: CIS-9.2.7
+#              match_output: '%SYSTEMROOT%\System32\logfiles\firewall\privatefw.log'
+#              value_type: 'private'
+#      description: (l1) ensure 'windows firewall - private - logging - name' is set to '%systemroot%\system32\logfiles\firewall\privatefw.log'
+#    windows_firewall_private_logging_size_limit :
+#      data:
+#        'Microsoft Windows Server 2008*':
+#          - 'LogMaxSizeKilobytes':
+#              tag: CIS-9.2.8
+#              match_output: '16384'
+#              value_type: 'private'
+#      description: (l1) ensure 'windows firewall - private - logging - size limit (kb)' is set to '16,384 kb or greater'
+#    windows_firewall_private_logging_log_dropped_packets :
+#      data:
+#        'Microsoft Windows Server 2008*':
+#          - 'LogBlocked':
+#              tag: CIS-9.2.9
+#              match_output: 'True'
+#              value_type: 'private'
+#      description: (l1) ensure 'windows firewall - private - logging - log dropped packets' is set to 'yes'
+#    windows_firewall_private_logging_log_successful_connections :
+#      data:
+#        'Microsoft Windows Server 2008*':
+#          - 'LogAllowed':
+#              tag: CIS-9.2.10
+#              match_output: 'True'
+#              value_type: 'private'
+#      description: (l1) ensure 'windows firewall - private - logging - log successful connections' is set to 'yes'
+#    windows_firewall_public_firewall_state :
+#      data:
+#        'Microsoft Windows Server 2008*':
+#          - 'Enabled':
+#              tag: CIS-9.3.1
+#              match_output: 'True'
+#              value_type: 'public'
+#      description: (l1) ensure 'windows firewall - public - firewall state' is set to 'on (recommended)'
+#    windows_firewall_public_inbound_connections :
+#      data:
+#        'Microsoft Windows Server 2008*':
+#          - 'DefaultInboundAction':
+#              tag: CIS-9.3.2
+#              match_output: 'Block'
+#              value_type: 'public'
+#      description: (l1) ensure 'windows firewall - public - inbound connections' is set to 'block (default)'
+#    windows_firewall_public_outbound_connections :
+#      data:
+#        'Microsoft Windows Server 2008*':
+#          - 'DefaultOutboundAction':
+#              tag: CIS-9.3.3
+#              match_output: 'Allow'
+#              value_type: 'public'
+#      description: (l1) ensure 'windows firewall - public - outbound connections' is set to 'allow (default)'
+#    windows_firewall_public_settings_display_a_notification :
+#      data:
+#        'Microsoft Windows Server 2008*':
+#          - 'NotifyOnListen':
+#              tag: CIS-9.3.4
+#              match_output: 'True'
+#              value_type: 'public'
+#      description: (l1) ensure 'windows firewall - public - settings - display a notification' is set to 'yes'
+#    windows_firewall_public_settings_apply_local_firewall_rules :
+#      data:
+#        'Microsoft Windows Server 2008*':
+#          - 'AllowLocalFirewallRules':
+#              tag: CIS-9.3.5
+#              match_output: 'False'
+#              value_type: 'public'
+#      description: (l1) ensure 'windows firewall - public - settings - apply local firewall rules' is set to 'no'
+#    windows_firewall_public_settings_apply_local_connection_security_rules :
+#      data:
+#        'Microsoft Windows Server 2008*':
+#          - 'AllowLocalIPsecRules':
+#              tag: CIS-9.3.6
+#              match_output: 'False'
+#              value_type: 'public'
+#      description: (l1) ensure 'windows firewall - public - settings - apply local connection security rules' is set to 'no'
+#    windows_firewall_public_logging_name :
+#      data:
+#        'Microsoft Windows Server 2008*':
+#          - 'LogFileName':
+#              tag: CIS-9.3.7
+#              match_output: '%SYSTEMROOT%\System32\logfiles\firewall\publicfw.log'
+#              value_type: 'public'
+#      description: (l1) ensure 'windows firewall - public - logging - name' is set to '%systemroot%\system32\logfiles\firewall\publicfw.log'
+#    windows_firewall_public_logging_size_limit_(kb :
+#      data:
+#        'Microsoft Windows Server 2008*':
+#          - 'LogMaxSizeKilobytes':
+#              tag: CIS-9.3.8
+#              match_output: '16384'
+#              value_type: 'public'
+#      description: (l1) ensure 'windows firewall - public - logging - size limit (kb)' is set to '16,384 kb or greater'
+#    windows_firewall_public_logging_log_dropped_packets :
+#      data:
+#        'Microsoft Windows Server 2008*':
+#          - 'LogBlocked':
+#              tag: CIS-9.3.9
+#              match_output: 'True'
+#              value_type: 'public'
+#      description: (l1) ensure 'windows firewall - public - logging - log dropped packets' is set to 'yes'
+#    windows_firewall_public_logging_log_successful_connections :
+#      data:
+#        'Microsoft Windows Server 2008*':
+#          - 'LogAllowed':
+#              tag: CIS-9.3.10
+#              match_output: 'True'
+#              value_type: 'public'
+#      description: (l1) ensure 'windows firewall - public - logging - log successful connections' is set to 'yes'
 
 win_auditpol:
   whitelist:
@@ -1475,7 +1475,7 @@ win_reg:
     Do not display network selection UI :
       data:
         'Microsoft Windows Server 2008*':
-          - ' HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System\LogonType':
+          - 'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System\LogonType':
               tag: CIS-18.8.24.1
               match_output: 'Enabled'
               value_type: 'equal'
@@ -1523,7 +1523,7 @@ win_reg:
     Turn off desktop gadgets :
       data:
         'Microsoft Windows Server 2008*':
-          - ' HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Windows\Sidebar\TurnOffSideb':
+          - 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Windows\Sidebar\TurnOffSideb':
               tag: CIS-18.9.16.1
               match_output: 'Enabled'
               value_type: 'equal'
@@ -1531,7 +1531,7 @@ win_reg:
     Turn off user-installed desktop gadgets :
       data:
         'Microsoft Windows Server 2008*':
-          - ' HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Windows\Sidebar\TurnOffUserInstalledGadget':
+          - 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Windows\Sidebar\TurnOffUserInstalledGadget':
               tag: CIS-18.9.16.2
               match_output: 'Enabled'
               value_type: 'equal'
@@ -1837,7 +1837,7 @@ win_reg:
     Allow remote access to the Plug and Play interface :
       data:
         'Microsoft Windows Server 2008*':
-          - ' HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\DeviceInstall\Settings\AllowRemoteRPC':
+          - 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\DeviceInstall\Settings\AllowRemoteRPC':
               tag: CIS-18.8.5.2
               match_output: 'Disabled'
               value_type: 'equal'


### PR DESCRIPTION
- Get-NetFirewallProfile not available on 2008. Disabling firewall
checks there until we figure out a workaround
- Added more checks for bad lines when fetching accounts in win_secedit
- Fix leading whitespace in reg checks