### PR TITLE
Added a fix for Debian hosts

### DIFF
--- a/hubblestack_nova/cve_scan_v2.py
+++ b/hubblestack_nova/cve_scan_v2.py
@@ -168,7 +168,7 @@ def audit(data_list, tags, verbose=False, show_profile=False, debug=False):
                         os.remove(cached_zip)
                         extracted_json = os.path.join(__opts__['cachedir'],
                                                       'cve_scan_cache',
-                                                      '%s_%s.json' % (os_name, os_version.replace('.', '')))
+                                                      '%s_%s.json' % (os_name, str(os_version).replace('.', '')))
                         log.debug('attempting to open %s', extracted_json)
                         with open(extracted_json, 'r') as json_file:
                             master_json = json.load(json_file)


### PR DESCRIPTION
Debian instances have a major version grain that is an integer. When
trying to call `.replace` on the `os_version` variable it was throwing
an exception due to this.