### PR TITLE
Fixes for at.deny and cron.deny

### DIFF
--- a/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v1.yaml
+++ b/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v1.yaml
@@ -434,17 +434,6 @@ stat:
           user: root
     description: /etc/anacrontab file be owned by root and must have permissions 600
       (Scored)
-  at_allow:
-    data:
-      CentOS Linux-7:
-      - /etc/at.allow:
-          gid: 0
-          group: root
-          mode: 600
-          tag: CIS-6.1.10
-          uid: 0
-          user: root
-    description: /etc/at.allow must be owned by root and have persmissions 600 (Scored)
   at_cron_allow:
     data:
       CentOS Linux-7:

--- a/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-1-0.yaml
@@ -808,17 +808,6 @@ service:
         - syslog-ng: CIS-4.2.2.1_running
       description: Ensure syslog-ng service is enabled
 stat:
-  at_allow:
-    data:
-      CentOS Linux-7:
-      - /etc/at.allow:
-          gid: 0
-          group: root
-          mode: 600
-          tag: CIS-5.1.8
-          uid: 0
-          user: root
-    description: /etc/at.allow must be owned by root and have persmissions 600 (Scored)
   at_cron_allow:
     data:
       CentOS Linux-7:

--- a/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-1-0.yaml
@@ -812,19 +812,19 @@ stat:
     data:
       CentOS Linux-7:
       - /etc/cron.deny:
-          gid: 0
-          group: root
-          mode: 600
+          gid: null
+          group: null
+          mode: null
           tag: CIS-5.1.8
-          uid: 0
-          user: root
+          uid: null
+          user: null
       - /etc/at.deny:
-          gid: 0
-          group: root
-          mode: 600
+          gid: null
+          group: null
+          mode: null
           tag: CIS-5.1.8
-          uid: 0
-          user: root
+          uid: null
+          user: null
       - /etc/cron.allow:
           gid: 0
           group: root

--- a/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2.yaml
+++ b/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2.yaml
@@ -788,17 +788,6 @@ service:
         CentOS Linux-7:
         - syslog-ng: CIS-4.2.2.1_running
 stat:
-  at_allow:
-    data:
-      CentOS Linux-7:
-      - /etc/at.allow:
-          gid: 0
-          group: root
-          mode: 600
-          tag: CIS-5.1.8
-          uid: 0
-          user: root
-    description: /etc/at.allow must be owned by root and have persmissions 600 (Scored)
   at_cron_allow:
     data:
       CentOS Linux-7:

--- a/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2.yaml
+++ b/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2.yaml
@@ -792,19 +792,19 @@ stat:
     data:
       CentOS Linux-7:
       - /etc/cron.deny:
-          gid: 0
-          group: root
-          mode: 600
+          gid: null
+          group: null
+          mode: null
           tag: CIS-5.1.8
-          uid: 0
-          user: root
+          uid: null
+          user: null
       - /etc/at.deny:
-          gid: 0
-          group: root
-          mode: 600
+          gid: null
+          group: null
+          mode: null
           tag: CIS-5.1.8
-          uid: 0
-          user: root
+          uid: null
+          user: null
       - /etc/cron.allow:
           gid: 0
           group: root

--- a/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v1.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v1.yaml
@@ -794,28 +794,28 @@ stat:
           gid: null
           group: null
           mode: null
-          tag: CIS-5.1.8
+          tag: CIS-6.1.11
           uid: null
           user: null
       - /etc/at.deny:
           gid: null
           group: null
           mode: null
-          tag: CIS-5.1.8
+          tag: CIS-6.1.11
           uid: null
           user: null
       - /etc/cron.allow:
           gid: 0
           group: root
           mode: 600
-          tag: CIS-5.1.8
+          tag: CIS-6.1.11
           uid: 0
           user: root
       - /etc/at.allow:
           gid: 0
           group: root
           mode: 600
-          tag: CIS-5.1.8
+          tag: CIS-6.1.11
           uid: 0
           user: root
     description: Restrict at/cron to authorized users (Scored)

--- a/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v1.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v1.yaml
@@ -787,17 +787,6 @@ service:
         Red Hat Enterprise Linux Server-7:
         - syslog-ng: CIS-4.2.2.1_running
 stat:
-  at_allow:
-    data:
-      Red Hat Enterprise Linux Server-7:
-      - /etc/at.allow:
-          gid: 0
-          group: root
-          mode: 600
-          tag: CIS-5.1.8
-          uid: 0
-          user: root
-    description: /etc/at.allow must be owned by root and have persmissions 600 (Scored)
   at_cron_allow:
     data:
       Red Hat Enterprise Linux Server-7:

--- a/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v1.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v1.yaml
@@ -791,19 +791,19 @@ stat:
     data:
       Red Hat Enterprise Linux Server-7:
       - /etc/cron.deny:
-          gid: 0
-          group: root
-          mode: 600
+          gid: null
+          group: null
+          mode: null
           tag: CIS-5.1.8
-          uid: 0
-          user: root
+          uid: null
+          user: null
       - /etc/at.deny:
-          gid: 0
-          group: root
-          mode: 600
+          gid: null
+          group: null
+          mode: null
           tag: CIS-5.1.8
-          uid: 0
-          user: root
+          uid: null
+          user: null
       - /etc/cron.allow:
           gid: 0
           group: root

--- a/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v2-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v2-1-0.yaml
@@ -812,19 +812,19 @@ stat:
     data:
       Red Hat Enterprise Linux Server-7:
       - /etc/cron.deny:
-          gid: 0
-          group: root
-          mode: 600
+          gid: null
+          group: null
+          mode: null
           tag: CIS-5.1.8
-          uid: 0
-          user: root
+          uid: null
+          user: null
       - /etc/at.deny:
-          gid: 0
-          group: root
-          mode: 600
+          gid: null
+          group: null
+          mode: null
           tag: CIS-5.1.8
-          uid: 0
-          user: root
+          uid: null
+          user: null
       - /etc/cron.allow:
           gid: 0
           group: root

--- a/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v2-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v2-1-0.yaml
@@ -808,17 +808,6 @@ service:
         - syslog-ng: CIS-4.2.2.1_running
       description: Ensure syslog-ng service is enabled
 stat:
-  at_allow:
-    data:
-      Red Hat Enterprise Linux Server-7:
-      - /etc/at.allow:
-          gid: 0
-          group: root
-          mode: 600
-          tag: CIS-5.1.8
-          uid: 0
-          user: root
-    description: /etc/at.allow must be owned by root and have persmissions 600 (Scored)
   at_cron_allow:
     data:
       Red Hat Enterprise Linux Server-7:

--- a/hubblestack_nova_profiles/cis/rhelw-7-level-1-scored-v1.yaml
+++ b/hubblestack_nova_profiles/cis/rhelw-7-level-1-scored-v1.yaml
@@ -767,17 +767,6 @@ service:
         Red Hat Enterprise Linux Workstation-7:
         - syslog-ng: CIS-4.2.2.1_running
 stat:
-  at_allow:
-    data:
-      Red Hat Enterprise Linux Workstation-7:
-      - /etc/at.allow:
-          gid: 0
-          group: root
-          mode: 600
-          tag: CIS-5.1.8
-          uid: 0
-          user: root
-    description: /etc/at.allow must be owned by root and have persmissions 600 (Scored)
   at_cron_allow:
     data:
       Red Hat Enterprise Linux Workstation-7:

--- a/hubblestack_nova_profiles/cis/rhelw-7-level-1-scored-v1.yaml
+++ b/hubblestack_nova_profiles/cis/rhelw-7-level-1-scored-v1.yaml
@@ -771,19 +771,19 @@ stat:
     data:
       Red Hat Enterprise Linux Workstation-7:
       - /etc/cron.deny:
-          gid: 0
-          group: root
-          mode: 600
+          gid: null
+          group: null
+          mode: null
           tag: CIS-5.1.8
-          uid: 0
-          user: root
+          uid: null
+          user: null
       - /etc/at.deny:
-          gid: 0
-          group: root
-          mode: 600
+          gid: null
+          group: null
+          mode: null
           tag: CIS-5.1.8
-          uid: 0
-          user: root
+          uid: null
+          user: null
       - /etc/cron.allow:
           gid: 0
           group: root

--- a/hubblestack_nova_profiles/cis/rhelw-7-level-1-scored-v1.yaml
+++ b/hubblestack_nova_profiles/cis/rhelw-7-level-1-scored-v1.yaml
@@ -774,28 +774,28 @@ stat:
           gid: null
           group: null
           mode: null
-          tag: CIS-5.1.8
+          tag: CIS-6.1.11
           uid: null
           user: null
       - /etc/at.deny:
           gid: null
           group: null
           mode: null
-          tag: CIS-5.1.8
+          tag: CIS-6.1.11
           uid: null
           user: null
       - /etc/cron.allow:
           gid: 0
           group: root
           mode: 600
-          tag: CIS-5.1.8
+          tag: CIS-6.1.11
           uid: 0
           user: root
       - /etc/at.allow:
           gid: 0
           group: root
           mode: 600
-          tag: CIS-5.1.8
+          tag: CIS-6.1.11
           uid: 0
           user: root
     description: Restrict at/cron to authorized users (Scored)

--- a/hubblestack_nova_profiles/cis/rhelw-7-level-1-scored-v2-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhelw-7-level-1-scored-v2-1-0.yaml
@@ -792,19 +792,19 @@ stat:
     data:
       Red Hat Enterprise Linux Workstation-7:
       - /etc/cron.deny:
-          gid: 0
-          group: root
-          mode: 600
+          gid: null
+          group: null
+          mode: null
           tag: CIS-5.1.8
-          uid: 0
-          user: root
+          uid: null
+          user: null
       - /etc/at.deny:
-          gid: 0
-          group: root
-          mode: 600
+          gid: null
+          group: null
+          mode: null
           tag: CIS-5.1.8
-          uid: 0
-          user: root
+          uid: null
+          user: null
       - /etc/cron.allow:
           gid: 0
           group: root

--- a/hubblestack_nova_profiles/cis/rhelw-7-level-1-scored-v2-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhelw-7-level-1-scored-v2-1-0.yaml
@@ -788,17 +788,6 @@ service:
         - syslog-ng: CIS-4.2.2.1_running
       description: Ensure syslog-ng service is enabled
 stat:
-  at_allow:
-    data:
-      Red Hat Enterprise Linux Workstation-7:
-      - /etc/at.allow:
-          gid: 0
-          group: root
-          mode: 600
-          tag: CIS-5.1.8
-          uid: 0
-          user: root
-    description: /etc/at.allow must be owned by root and have persmissions 600 (Scored)
   at_cron_allow:
     data:
       Red Hat Enterprise Linux Workstation-7:

--- a/hubblestack_nova_profiles/cis/ubuntu-1404-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/ubuntu-1404-level-1-scored-v1-0-0.yaml
@@ -788,19 +788,19 @@ stat:
     data:
       Ubuntu-14.04:
       - /etc/cron.deny:
-          gid: 0
-          group: root
-          mode: 600
+          gid: null
+          group: null
+          mode: null
           tag: CIS-9.1.8
-          uid: 0
-          user: root
+          uid: null
+          user: null
       - /etc/at.deny:
-          gid: 0
-          group: root
-          mode: 600
+          gid: null
+          group: null
+          mode: null
           tag: CIS-9.1.8
-          uid: 0
-          user: root
+          uid: null
+          user: null
       - /etc/cron.allow:
           gid: 0
           group: root

--- a/hubblestack_nova_profiles/cis/ubuntu-1404-level-1-scored-v1.yaml
+++ b/hubblestack_nova_profiles/cis/ubuntu-1404-level-1-scored-v1.yaml
@@ -788,19 +788,19 @@ stat:
     data:
       Ubuntu-14.04:
       - /etc/cron.deny:
-          gid: 0
-          group: root
-          mode: 600
+          gid: null
+          group: null
+          mode: null
           tag: CIS-9.1.8
-          uid: 0
-          user: root
+          uid: null
+          user: null
       - /etc/at.deny:
-          gid: 0
-          group: root
-          mode: 600
+          gid: null
+          group: null
+          mode: null
           tag: CIS-9.1.8
-          uid: 0
-          user: root
+          uid: null
+          user: null
       - /etc/cron.allow:
           gid: 0
           group: root


### PR DESCRIPTION
The CIS benchmarks recommend that /etc/at.deny and /etc/cron.deny not exist, but the profiles required that they exist. This update ensures that the files are not present.

Also, there were duplicate checks for at.allow in the same area, and some incorrect tags. Those have also been fixed.