### PR TITLE
Correct tag format on CIS-3.3.1

### DIFF
--- a/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-1-0.yaml
@@ -1114,7 +1114,7 @@ sysctl:
       CentOS Linux-7:
       - net.ipv6.conf.all.accept_ra:
           match_output: '0'
-          tag: CIS 3.3.1
+          tag: CIS-3.3.1
       - net.ipv6.conf.default.accept_ra:
           match_output: '0'
           tag: CIS-3.3.1

--- a/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2.yaml
+++ b/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2.yaml
@@ -1096,7 +1096,7 @@ sysctl:
       CentOS Linux-7:
       - net.ipv6.conf.all.accept_ra:
           match_output: '0'
-          tag: CIS 3.3.1
+          tag: CIS-3.3.1
       - net.ipv6.conf.default.accept_ra:
           match_output: '0'
           tag: CIS-3.3.1

--- a/hubblestack_nova_profiles/cis/coreos-level-1.yaml
+++ b/hubblestack_nova_profiles/cis/coreos-level-1.yaml
@@ -996,7 +996,7 @@ sysctl:
       *CoreOS*:
       - net.ipv6.conf.all.accept_ra:
           match_output: '0'
-          tag: CIS 3.3.1
+          tag: CIS-3.3.1
       - net.ipv6.conf.default.accept_ra:
           match_output: '0'
           tag: CIS-3.3.1

--- a/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v1.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v1.yaml
@@ -1095,7 +1095,7 @@ sysctl:
       Red Hat Enterprise Linux Server-7:
       - net.ipv6.conf.all.accept_ra:
           match_output: '0'
-          tag: CIS 3.3.1
+          tag: CIS-3.3.1
       - net.ipv6.conf.default.accept_ra:
           match_output: '0'
           tag: CIS-3.3.1

--- a/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v2-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v2-1-0.yaml
@@ -1114,7 +1114,7 @@ sysctl:
       Red Hat Enterprise Linux Server-7:
       - net.ipv6.conf.all.accept_ra:
           match_output: '0'
-          tag: CIS 3.3.1
+          tag: CIS-3.3.1
       - net.ipv6.conf.default.accept_ra:
           match_output: '0'
           tag: CIS-3.3.1

--- a/hubblestack_nova_profiles/cis/rhelw-7-level-1-scored-v1.yaml
+++ b/hubblestack_nova_profiles/cis/rhelw-7-level-1-scored-v1.yaml
@@ -1075,7 +1075,7 @@ sysctl:
       Red Hat Enterprise Linux Workstation-7:
       - net.ipv6.conf.all.accept_ra:
           match_output: '0'
-          tag: CIS 3.3.1
+          tag: CIS-3.3.1
       - net.ipv6.conf.default.accept_ra:
           match_output: '0'
           tag: CIS-3.3.1

--- a/hubblestack_nova_profiles/cis/rhelw-7-level-1-scored-v2-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhelw-7-level-1-scored-v2-1-0.yaml
@@ -1094,7 +1094,7 @@ sysctl:
       Red Hat Enterprise Linux Workstation-7:
       - net.ipv6.conf.all.accept_ra:
           match_output: '0'
-          tag: CIS 3.3.1
+          tag: CIS-3.3.1
       - net.ipv6.conf.default.accept_ra:
           match_output: '0'
           tag: CIS-3.3.1


### PR DESCRIPTION
Add missing hyphen for CIS-3.3.1 to match other CIS tags