### PR TITLE
Move output formatting code to hubble.py

### DIFF
--- a/_modules/hubble.py
+++ b/_modules/hubble.py
@@ -135,13 +135,7 @@ def audit(configs=None,
     configs = [os.path.join(os.path.sep, os.path.join(*(con.split('.yaml')[0]).split('.')))
                for con in configs]
 
-    ret = _run_audit(
-        configs,
-        tags,
-        verbose=verbose,
-        debug=debug,
-        show_profile=show_profile
-    )
+    ret = _run_audit(configs, tags, debug=debug)
 
     terse_results = {}
     verbose_results = {}
@@ -228,7 +222,7 @@ def audit(configs=None,
 
     return results
 
-def _run_audit(configs, tags, verbose, debug, show_profile):
+def _run_audit(configs, tags, debug):
 
     results = {}
 
@@ -269,11 +263,7 @@ def _run_audit(configs, tags, verbose, debug, show_profile):
     # We can revisit if this ever becomes a big bottleneck
     for key, func in __nova__._dict.iteritems():
         try:
-            ret = func(data_list,
-                       tags,
-                       verbose=verbose,
-                       show_profile=show_profile,
-                       debug=debug)
+            ret = func(data_list, tags, debug=debug)
         except Exception as exc:
             log.error('Exception occurred in nova module:')
             log.error(traceback.format_exc())

--- a/_modules/hubble.py
+++ b/_modules/hubble.py
@@ -83,9 +83,7 @@ def audit(configs=None,
         `hubblestack:nova:show_compliance` in minion config/pillar.
 
     show_profile
-        Whether to add the profile path to the verbose output for audits.
-        Defaults to True. Configurable via `hubblestack:nova:show_profile`
-        in minion config/pillar.
+        DEPRECATED
 
     called_from_top
         Ignore this argument. It is used for distinguishing between user-calls
@@ -107,9 +105,7 @@ def audit(configs=None,
     if configs is None:
         return top(verbose=verbose,
                    show_success=show_success,
-                   show_compliance=show_compliance,
-                   show_profile=show_profile,
-                   debug=debug)
+                   show_compliance=show_compliance)
 
     if __salt__['config.get']('hubblestack:nova:autoload', True):
         load()
@@ -122,8 +118,10 @@ def audit(configs=None,
         show_success = __salt__['config.get']('hubblestack:nova:show_success', True)
     if show_compliance is None:
         show_compliance = __salt__['config.get']('hubblestack:nova:show_compliance', True)
-    if show_profile is None:
-        show_profile = __salt__['config.get']('hubblestack:nova:show_profile', True)
+    if show_profile is not None:
+        log.warning(
+            'Keyword argument \'show_profile\' is no longer supported'
+        )
     if debug is None:
         debug = __salt__['config.get']('hubblestack:nova:debug', False)
 
@@ -389,9 +387,7 @@ def top(topfile='top.nova',
         `hubblestack:nova:show_compliance` in minion config/pillar.
 
     show_profile
-        Whether to add the profile path to the verbose output for audits.
-        Defaults to True. Configurable via `hubblestack:nova:show_profile`
-        in minion config/pillar.
+        DEPRECATED
 
     debug
         Whether to log additional information to help debug nova. Defaults to
@@ -417,8 +413,10 @@ def top(topfile='top.nova',
         show_success = __salt__['config.get']('hubblestack:nova:show_success', True)
     if show_compliance is None:
         show_compliance = __salt__['config.get']('hubblestack:nova:show_compliance', True)
-    if show_profile is None:
-        show_profile = __salt__['config.get']('hubblestack:nova:show_profile', True)
+    if show_profile is not None:
+        log.warning(
+            'Keyword argument \'show_profile\' is no longer supported'
+        )
     if debug is None:
         debug = __salt__['config.get']('hubblestack:nova:debug', False)
 
@@ -456,9 +454,7 @@ def top(topfile='top.nova',
                     verbose=verbose,
                     show_success=True,
                     show_compliance=False,
-                    show_profile=show_profile,
-                    called_from_top=True,
-                    debug=debug)
+                    called_from_top=True)
 
         # Merge in the results
         for key, val in ret.iteritems():

--- a/_modules/hubble.py
+++ b/_modules/hubble.py
@@ -135,6 +135,30 @@ def audit(configs=None,
     configs = [os.path.join(os.path.sep, os.path.join(*(con.split('.yaml')[0]).split('.')))
                for con in configs]
 
+    ret = _run_audit(
+        configs,
+        tags,
+        verbose=verbose,
+        debug=debug,
+        show_profile=show_profile
+    )
+
+    if show_compliance:
+        compliance = _calculate_compliance(results)
+        if compliance:
+            results['Compliance'] = compliance
+
+    if not called_from_top and not results:
+        results['Messages'] = 'No audits matched this host in the specified profiles.'
+
+    if not show_success and 'Success' in results:
+        results.pop('Success')
+
+    return ret
+
+
+def _run_audit(configs, tags, verbose, debug, show_profile):
+
     results = {}
 
     # Compile a list of audit data sets which we need to run
@@ -243,20 +267,9 @@ def audit(configs=None,
         for failure_index in reversed(sorted(set(failures_to_remove))):
             results['Failure'].pop(failure_index)
 
-    if show_compliance:
-        compliance = _calculate_compliance(results)
-        if compliance:
-            results['Compliance'] = compliance
-
     for key in results.keys():
         if not results[key]:
             results.pop(key)
-
-    if not called_from_top and not results:
-        results['Messages'] = 'No audits matched this host in the specified profiles.'
-
-    if not show_success and 'Success' in results:
-        results.pop('Success')
 
     return results
 

--- a/hubblestack_nova/command.py
+++ b/hubblestack_nova/command.py
@@ -170,63 +170,6 @@ def audit(data_list, tags, verbose=False, show_profile=False, debug=False):
                     else:
                         ret['Failure'].append(tag_data)
 
-    failure = []
-    success = []
-    controlled = []
-
-    if not verbose:
-        # Pull out just the tag and description
-        tags_descriptions = set()
-
-        for tag_data in ret['Failure']:
-            tag = tag_data['tag']
-            description = tag_data.get('description')
-            if (tag, description) not in tags_descriptions:
-                failure.append({tag: description})
-                tags_descriptions.add((tag, description))
-
-        tags_descriptions = set()
-
-        for tag_data in ret['Success']:
-            tag = tag_data['tag']
-            description = tag_data.get('description')
-            if (tag, description) not in tags_descriptions:
-                success.append({tag: description})
-                tags_descriptions.add((tag, description))
-
-        control_reasons = set()
-
-        for tag_data in ret['Controlled']:
-            tag = tag_data['tag']
-            control_reason = tag_data.get('control', '')
-            description = tag_data.get('description')
-            if (tag, description, control_reason) not in control_reasons:
-                tag_dict = {'description': description,
-                        'control': control_reason}
-                controlled.append({tag: tag_dict})
-                control_reasons.add((tag, description, control_reason))
-
-    else:
-        # Format verbose output as single-key dictionaries with tag as key
-        for tag_data in ret['Failure']:
-            tag = tag_data['tag']
-            failure.append({tag: tag_data})
-
-        for tag_data in ret['Success']:
-            tag = tag_data['tag']
-            success.append({tag: tag_data})
-
-        for tag_data in ret['Controlled']:
-            tag = tag_data['tag']
-            controlled.append({tag: tag_data})
-
-    ret['Controlled'] = controlled
-    ret['Success'] = success
-    ret['Failure'] = failure
-
-    if not ret['Controlled']:
-        ret.pop('Controlled')
-
     return ret
 
 

--- a/hubblestack_nova/command.py
+++ b/hubblestack_nova/command.py
@@ -87,16 +87,13 @@ def __virtual__():
     return True
 
 
-def audit(data_list, tags, verbose=False, show_profile=False, debug=False):
+def audit(data_list, tags, debug=False):
     '''
     Run the command audits contained in the data_list
     '''
     __data__ = {}
     for profile, data in data_list:
-        if show_profile:
-            _merge_yaml(__data__, data, profile)
-        else:
-            _merge_yaml(__data__, data)
+        _merge_yaml(__data__, data, profile)
     __tags__ = _get_tags(__data__)
 
     if debug:

--- a/hubblestack_nova/cve_scan.py
+++ b/hubblestack_nova/cve_scan.py
@@ -21,7 +21,7 @@ def __virtual__():
     return False, 'This module requires Linux and the oscap binary'
 
 
-def audit(data_list, tags, verbose=False, show_profile=False, debug=False):
+def audit(data_list, tags, debug=False):
     '''
     Run the network.netstat command
     '''

--- a/hubblestack_nova/cve_scan_v2.py
+++ b/hubblestack_nova/cve_scan_v2.py
@@ -92,7 +92,7 @@ def __virtual__():
     return not salt.utils.is_windows()
 
 
-def audit(data_list, tags, verbose=False, show_profile=False, debug=False):
+def audit(data_list, tags, debug=False):
     '''
     Main audit function. See module docstring for more information on usage.
     '''
@@ -224,9 +224,9 @@ def audit(data_list, tags, verbose=False, show_profile=False, debug=False):
                                     vulnerable = affected_obj
                 if vulnerable:
                     if vulnerable.score < min_score:
-                        ret['Controlled'].append(vulnerable.get_report(verbose, show_profile, profile))
+                        ret['Controlled'].append(vulnerable.get_report(profile))
                     else:
-                        ret['Failure'].append(vulnerable.get_report(verbose, show_profile, profile))
+                        ret['Failure'].append(vulnerable.get_report(profile))
 
     if tags != '*':
         log.debug("tags: %s", tags)
@@ -379,7 +379,7 @@ class VulnerablePkg:
         self.oudated_version = None
 
 
-    def get_report(self, verbose, show_profile, profile):
+    def get_report(self, profile):
         '''
         Return the dictionary of what should be reported in failures, based on verbose.
         '''

--- a/hubblestack_nova/cve_scan_v2.py
+++ b/hubblestack_nova/cve_scan_v2.py
@@ -383,21 +383,16 @@ class VulnerablePkg:
         '''
         Return the dictionary of what should be reported in failures, based on verbose.
         '''
-        uid = self.pkg + '-' + self.pkg_version
-        if verbose:
-            report = {
-                'href': self.href,
-                'affected_version': self.pkg_version,
-                'reporter': self.reporter,
-                'score': self.score,
-                'cve_list': self.cve_list,
-                'affected_pkg': self.pkg,
-                'local_version': self.oudated_version,
-                'description': self.title
-            }
-            if show_profile:
-                report['nova_profile'] = profile
-        else:
-            report = self.title
-        return {uid: report}
+        return {
+            'tag': self.pkg + '-' + self.pkg_version,
+            'href': self.href,
+            'affected_version': self.pkg_version,
+            'reporter': self.reporter,
+            'score': self.score,
+            'cve_list': self.cve_list,
+            'affected_pkg': self.pkg,
+            'local_version': self.oudated_version,
+            'description': self.title,
+            'nova_profile': profile
+        }
 

--- a/hubblestack_nova/firewall.py
+++ b/hubblestack_nova/firewall.py
@@ -163,63 +163,6 @@ def audit(data_list, tags, verbose=False, show_profile=False, debug=False):
                 else:
                     ret['Failure'].append(tag_data)
 
-    failure = []
-    success = []
-    controlled = []
-
-    if not verbose:
-        # Pull out just the tag and description
-        tags_descriptions = set()
-
-        for tag_data in ret['Failure']:
-            tag = tag_data['tag']
-            description = tag_data.get('description')
-            if (tag, description) not in tags_descriptions:
-                failure.append({tag: description})
-                tags_descriptions.add((tag, description))
-
-        tags_descriptions = set()
-
-        for tag_data in ret['Success']:
-            tag = tag_data['tag']
-            description = tag_data.get('description')
-            if (tag, description) not in tags_descriptions:
-                success.append({tag: description})
-                tags_descriptions.add((tag, description))
-
-        control_reasons = set()
-
-        for tag_data in ret['Controlled']:
-            tag = tag_data['tag']
-            control_reason = tag_data.get('control', '')
-            description = tag_data.get('description')
-            if (tag, description, control_reason) not in control_reasons:
-                tag_dict = {'description': description,
-                        'control': control_reason}
-                controlled.append({tag: tag_dict})
-                control_reasons.add((tag, description, control_reason))
-
-    else:
-        # Format verbose output as single-key dictionaries with tag as key
-        for tag_data in ret['Failure']:
-            tag = tag_data['tag']
-            failure.append({tag: tag_data})
-
-        for tag_data in ret['Success']:
-            tag = tag_data['tag']
-            success.append({tag: tag_data})
-
-        for tag_data in ret['Controlled']:
-            tag = tag_data['tag']
-            controlled.append({tag: tag_data})
-
-    ret['Controlled'] = controlled
-    ret['Success'] = success
-    ret['Failure'] = failure
-
-    if not ret['Controlled']:
-        ret.pop('Controlled')
-
     return ret
 
 

--- a/hubblestack_nova/firewall.py
+++ b/hubblestack_nova/firewall.py
@@ -99,13 +99,10 @@ def __virtual__():
     return True
 
 
-def audit(data_list, tags, verbose=False, show_profile=False, debug=False):
+def audit(data_list, tags, debug=False):
     __data__ = {}
     for profile, data in data_list:
-        if show_profile:
-            _merge_yaml(__data__, data, profile)
-        else:
-            _merge_yaml(__data__, data)
+        _merge_yaml(__data__, data, profile)
     __tags__ = _get_tags(__data__)
 
     if debug:

--- a/hubblestack_nova/grep.py
+++ b/hubblestack_nova/grep.py
@@ -148,63 +148,6 @@ def audit(data_list, tags, verbose=False, show_profile=False, debug=False):
                     else:
                         ret['Failure'].append(tag_data)
 
-    failure = []
-    success = []
-    controlled = []
-
-    if not verbose:
-        # Pull out just the tag and description
-        tags_descriptions = set()
-
-        for tag_data in ret['Failure']:
-            tag = tag_data['tag']
-            description = tag_data.get('description')
-            if (tag, description) not in tags_descriptions:
-                failure.append({tag: description})
-                tags_descriptions.add((tag, description))
-
-        tags_descriptions = set()
-
-        for tag_data in ret['Success']:
-            tag = tag_data['tag']
-            description = tag_data.get('description')
-            if (tag, description) not in tags_descriptions:
-                success.append({tag: description})
-                tags_descriptions.add((tag, description))
-
-        control_reasons = set()
-
-        for tag_data in ret['Controlled']:
-            tag = tag_data['tag']
-            control_reason = tag_data.get('control', '')
-            description = tag_data.get('description')
-            if (tag, description, control_reason) not in control_reasons:
-                tag_dict = {'description': description,
-                        'control': control_reason}
-                controlled.append({tag: tag_dict})
-                control_reasons.add((tag, description, control_reason))
-
-    else:
-        # Format verbose output as single-key dictionaries with tag as key
-        for tag_data in ret['Failure']:
-            tag = tag_data['tag']
-            failure.append({tag: tag_data})
-
-        for tag_data in ret['Success']:
-            tag = tag_data['tag']
-            success.append({tag: tag_data})
-
-        for tag_data in ret['Controlled']:
-            tag = tag_data['tag']
-            controlled.append({tag: tag_data})
-
-    ret['Controlled'] = controlled
-    ret['Success'] = success
-    ret['Failure'] = failure
-
-    if not ret['Controlled']:
-        ret.pop('Controlled')
-
     return ret
 
 

--- a/hubblestack_nova/grep.py
+++ b/hubblestack_nova/grep.py
@@ -73,16 +73,13 @@ def __virtual__():
     return True
 
 
-def audit(data_list, tags, verbose=False, show_profile=False, debug=False):
+def audit(data_list, tags, debug=False):
     '''
     Run the grep audits contained in the YAML files processed by __virtual__
     '''
     __data__ = {}
     for profile, data in data_list:
-        if show_profile:
-            _merge_yaml(__data__, data, profile)
-        else:
-            _merge_yaml(__data__, data)
+        _merge_yaml(__data__, data, profile)
     __tags__ = _get_tags(__data__)
 
     if debug:

--- a/hubblestack_nova/misc.py
+++ b/hubblestack_nova/misc.py
@@ -59,16 +59,13 @@ def __virtual__():
     return True
 
 
-def audit(data_list, tags, verbose=False, show_profile=False, debug=False):
+def audit(data_list, tags, debug=False):
     '''
     Run the misc audits contained in the data_list
     '''
     __data__ = {}
     for profile, data in data_list:
-        if show_profile:
-            _merge_yaml(__data__, data, profile)
-        else:
-            _merge_yaml(__data__, data)
+        _merge_yaml(__data__, data, profile)
     __tags__ = _get_tags(__data__)
 
     if debug:

--- a/hubblestack_nova/misc.py
+++ b/hubblestack_nova/misc.py
@@ -108,63 +108,6 @@ def audit(data_list, tags, verbose=False, show_profile=False, debug=False):
                 else:
                     ret['Failure'].append(tag_data)
 
-    failure = []
-    success = []
-    controlled = []
-
-    if not verbose:
-        # Pull out just the tag and description
-        tags_descriptions = set()
-
-        for tag_data in ret['Failure']:
-            tag = tag_data['tag']
-            description = tag_data.get('description')
-            if (tag, description) not in tags_descriptions:
-                failure.append({tag: description})
-                tags_descriptions.add((tag, description))
-
-        tags_descriptions = set()
-
-        for tag_data in ret['Success']:
-            tag = tag_data['tag']
-            description = tag_data.get('description')
-            if (tag, description) not in tags_descriptions:
-                success.append({tag: description})
-                tags_descriptions.add((tag, description))
-
-        control_reasons = set()
-
-        for tag_data in ret['Controlled']:
-            tag = tag_data['tag']
-            control_reason = tag_data.get('control', '')
-            description = tag_data.get('description')
-            if (tag, description, control_reason) not in control_reasons:
-                tag_dict = {'description': description,
-                        'control': control_reason}
-                controlled.append({tag: tag_dict})
-                control_reasons.add((tag, description, control_reason))
-
-    else:
-        # Format verbose output as single-key dictionaries with tag as key
-        for tag_data in ret['Failure']:
-            tag = tag_data['tag']
-            failure.append({tag: tag_data})
-
-        for tag_data in ret['Success']:
-            tag = tag_data['tag']
-            success.append({tag: tag_data})
-
-        for tag_data in ret['Controlled']:
-            tag = tag_data['tag']
-            controlled.append({tag: tag_data})
-
-    ret['Controlled'] = controlled
-    ret['Success'] = success
-    ret['Failure'] = failure
-
-    if not ret['Controlled']:
-        ret.pop('Controlled')
-
     return ret
 
 

--- a/hubblestack_nova/netstat.py
+++ b/hubblestack_nova/netstat.py
@@ -62,25 +62,24 @@ def audit(data_list, tags, verbose=False, show_profile=False, debug=True):
         return ret
 
     for address_data in __salt__['network.netstat']():
-        address = address_data['local-address']
+
         success = False
         for whitelisted_address in __tags__:
-            if fnmatch.fnmatch(address, whitelisted_address):
-                success_data = {address: __tags__[whitelisted_address]['id']}
-                if verbose:
-                    success_data = {address: __tags__[whitelisted_address]}
-                    success_data[address].update(address_data)
-                    success_data[address]['description'] = __tags__[whitelisted_address]['id']
-                ret['Success'].append(success_data)
+            if fnmatch.fnmatch(address_data['local-address'], whitelisted_address):
+                address_data.update({
+                    'tag': __tags__[whitelisted_address]['address'][0],
+                    'description': __tags__[whitelisted_address]['id'],
+                    'nova_profile': __tags__[whitelisted_address]['nova_profile']
+                })
+                ret['Success'].append(address_data)
                 success = True
                 break
         if success is False:
-            failure_data = {address: address_data['program']}
-            if verbose:
-                failure_data = {address: {'program': address_data['program']}}
-                failure_data[address].update(address_data)
-                failure_data[address]['description'] = address_data['program']
-                failure_data[address]['nova_profile'] = 'netstat'
-            ret['Failure'].append(failure_data)
+            address_data.update({
+                'tag': address_data['local-address'],
+                'description': address_data['program'],
+                'nova_profile': 'netstat'
+            })
+            ret['Failure'].append(address_data)
 
     return ret

--- a/hubblestack_nova/netstat.py
+++ b/hubblestack_nova/netstat.py
@@ -36,7 +36,7 @@ def __virtual__():
     return False, 'No network.netstat function found'
 
 
-def audit(data_list, tags, verbose=False, show_profile=False, debug=True):
+def audit(data_list, tags, debug=True):
     '''
     Run the network.netstat command
     '''
@@ -49,8 +49,7 @@ def audit(data_list, tags, verbose=False, show_profile=False, debug=True):
                 if 'address' in check_args:
                     tag_args = copy.deepcopy(check_args)
                     tag_args['id'] = check
-                    if show_profile:
-                        tag_args['nova_profile'] = profile
+                    tag_args['nova_profile'] = profile
                     if isinstance(check_args['address'], list):
                         for address in check_args['address']:
                             __tags__[address] = tag_args

--- a/hubblestack_nova/openssl.py
+++ b/hubblestack_nova/openssl.py
@@ -99,13 +99,10 @@ def __virtual__():
     return True
 
 
-def audit(data_list, tags, verbose=False, show_profile=False, debug=True):
+def audit(data_list, tags, debug=True):
     __data__ = {}
     for profile, data in data_list:
-        if show_profile:
-            _merge_yaml(__data__, data, profile)
-        else:
-            _merge_yaml(__data__, data)
+        _merge_yaml(__data__, data, profile)
     __tags__ = _get_tags(__data__)
 
     if debug:

--- a/hubblestack_nova/openssl.py
+++ b/hubblestack_nova/openssl.py
@@ -154,63 +154,6 @@ def audit(data_list, tags, verbose=False, show_profile=False, debug=True):
                     tag_data['reason'] = failing_reason
                     ret['Failure'].append(tag_data)
 
-    failure = []
-    success = []
-    controlled = []
-
-    if not verbose:
-        # Pull out just the tag and description
-        tags_descriptions = set()
-
-        for tag_data in ret['Failure']:
-            tag = tag_data['tag']
-            description = tag_data.get('description')
-            if (tag, description) not in tags_descriptions:
-                failure.append({tag: description})
-                tags_descriptions.add((tag, description))
-
-        tags_descriptions = set()
-
-        for tag_data in ret['Success']:
-            tag = tag_data['tag']
-            description = tag_data.get('description')
-            if (tag, description) not in tags_descriptions:
-                success.append({tag: description})
-                tags_descriptions.add((tag, description))
-
-        control_reasons = set()
-
-        for tag_data in ret['Controlled']:
-            tag = tag_data['tag']
-            description = tag_data.get('description')
-            control_reason = tag_data.get('control', '')
-            if (tag, description, control_reason) not in control_reasons:
-                tag_dict = {'description': description,
-                            'control': control_reason}
-                controlled.append({tag: tag_dict})
-                control_reasons.add((tag, description, control_reason))
-
-    else:
-        # Format verbose output as single-key dictionaries with tag as key
-        for tag_data in ret['Failure']:
-            tag = tag_data['tag']
-            failure.append({tag: tag_data})
-
-        for tag_data in ret['Success']:
-            tag = tag_data['tag']
-            success.append({tag: tag_data})
-
-        for tag_data in ret['Controlled']:
-            tag = tag_data['tag']
-            controlled.append({tag: tag_data})
-
-    ret['Controlled'] = controlled
-    ret['Success'] = success
-    ret['Failure'] = failure
-
-    if not ret['Controlled']:
-        ret.pop('Controlled')
-
     return ret
 
 

--- a/hubblestack_nova/pkg.py
+++ b/hubblestack_nova/pkg.py
@@ -158,63 +158,6 @@ def audit(data_list, tags, verbose=False, show_profile=False, debug=False):
                         else:
                             ret['Failure'].append(tag_data)
 
-    failure = []
-    success = []
-    controlled = []
-
-    if not verbose:
-        # Pull out just the tag and description
-        tags_descriptions = set()
-
-        for tag_data in ret['Failure']:
-            tag = tag_data['tag']
-            description = tag_data.get('description')
-            if (tag, description) not in tags_descriptions:
-                failure.append({tag: description})
-                tags_descriptions.add((tag, description))
-
-        tags_descriptions = set()
-
-        for tag_data in ret['Success']:
-            tag = tag_data['tag']
-            description = tag_data.get('description')
-            if (tag, description) not in tags_descriptions:
-                success.append({tag: description})
-                tags_descriptions.add((tag, description))
-
-        control_reasons = set()
-
-        for tag_data in ret['Controlled']:
-            tag = tag_data['tag']
-            control_reason = tag_data.get('control', '')
-            description = tag_data.get('description')
-            if (tag, description, control_reason) not in control_reasons:
-                tag_dict = {'description': description,
-                        'control': control_reason}
-                controlled.append({tag: tag_dict})
-                control_reasons.add((tag, description, control_reason))
-
-    else:
-        # Format verbose output as single-key dictionaries with tag as key
-        for tag_data in ret['Failure']:
-            tag = tag_data['tag']
-            failure.append({tag: tag_data})
-
-        for tag_data in ret['Success']:
-            tag = tag_data['tag']
-            success.append({tag: tag_data})
-
-        for tag_data in ret['Controlled']:
-            tag = tag_data['tag']
-            controlled.append({tag: tag_data})
-
-    ret['Controlled'] = controlled
-    ret['Success'] = success
-    ret['Failure'] = failure
-
-    if not ret['Controlled']:
-        ret.pop('Controlled')
-
     return ret
 
 

--- a/hubblestack_nova/pkg.py
+++ b/hubblestack_nova/pkg.py
@@ -79,16 +79,13 @@ def __virtual__():
     return True
 
 
-def audit(data_list, tags, verbose=False, show_profile=False, debug=False):
+def audit(data_list, tags, debug=False):
     '''
     Run the pkg audits contained in the YAML files processed by __virtual__
     '''
     __data__ = {}
     for profile, data in data_list:
-        if show_profile:
-            _merge_yaml(__data__, data, profile)
-        else:
-            _merge_yaml(__data__, data)
+        _merge_yaml(__data__, data, profile)
     __tags__ = _get_tags(__data__)
 
     if debug:

--- a/hubblestack_nova/pkgng_audit.py
+++ b/hubblestack_nova/pkgng_audit.py
@@ -20,7 +20,7 @@ def __virtual__():
     return True
 
 
-def audit(data_list, tags, verbose=False, show_profile=False, debug=False):
+def audit(data_list, tags, debug=False):
     '''
     Run the pkg.audit command
     '''
@@ -42,8 +42,7 @@ def audit(data_list, tags, verbose=False, show_profile=False, debug=False):
 
     salt_ret = __salt__['pkg.audit']()
     results = {'pkgng_audit': {'result': salt_ret}}
-    if show_profile:
-        results['pkng_audit']['nova_profile'] = profile
+    results['pkng_audit']['nova_profile'] = profile
     if not verbose:
         results = salt_ret
     if '0 problem(s)' not in salt_ret:

--- a/hubblestack_nova/service.py
+++ b/hubblestack_nova/service.py
@@ -114,63 +114,6 @@ def audit(data_list, tags, verbose=False, show_profile=False, debug=False):
                     else:
                         ret['Failure'].append(tag_data)
 
-    failure = []
-    success = []
-    controlled = []
-
-    if not verbose:
-        # Pull out just the tag and description
-        tags_descriptions = set()
-
-        for tag_data in ret['Failure']:
-            tag = tag_data['tag']
-            description = tag_data.get('description')
-            if (tag, description) not in tags_descriptions:
-                failure.append({tag: description})
-                tags_descriptions.add((tag, description))
-
-        tags_descriptions = set()
-
-        for tag_data in ret['Success']:
-            tag = tag_data['tag']
-            description = tag_data.get('description')
-            if (tag, description) not in tags_descriptions:
-                success.append({tag: description})
-                tags_descriptions.add((tag, description))
-
-        control_reasons = set()
-
-        for tag_data in ret['Controlled']:
-            tag = tag_data['tag']
-            control_reason = tag_data.get('control', '')
-            description = tag_data.get('description')
-            if (tag, description, control_reason) not in control_reasons:
-                tag_dict = {'description': description,
-                        'control': control_reason}
-                controlled.append({tag: tag_dict})
-                control_reasons.add((tag, description, control_reason))
-
-    else:
-        # Format verbose output as single-key dictionaries with tag as key
-        for tag_data in ret['Failure']:
-            tag = tag_data['tag']
-            failure.append({tag: tag_data})
-
-        for tag_data in ret['Success']:
-            tag = tag_data['tag']
-            success.append({tag: tag_data})
-
-        for tag_data in ret['Controlled']:
-            tag = tag_data['tag']
-            controlled.append({tag: tag_data})
-
-    ret['Controlled'] = controlled
-    ret['Success'] = success
-    ret['Failure'] = failure
-
-    if not ret['Controlled']:
-        ret.pop('Controlled')
-
     return ret
 
 

--- a/hubblestack_nova/service.py
+++ b/hubblestack_nova/service.py
@@ -72,16 +72,13 @@ def __virtual__():
     return True
 
 
-def audit(data_list, tags, verbose=False, show_profile=False, debug=False):
+def audit(data_list, tags, debug=False):
     '''
     Run the service audits contained in the YAML files processed by __virtual__
     '''
     __data__ = {}
     for profile, data in data_list:
-        if show_profile:
-            _merge_yaml(__data__, data, profile)
-        else:
-            _merge_yaml(__data__, data)
+        _merge_yaml(__data__, data, profile)
     __tags__ = _get_tags(__data__)
 
     if debug:

--- a/hubblestack_nova/stat.py
+++ b/hubblestack_nova/stat.py
@@ -57,16 +57,13 @@ def __virtual__():
     return True
 
 
-def audit(data_list, tags, verbose=False, show_profile=False, debug=False):
+def audit(data_list, tags, debug=False):
     '''
     Run the stat audits contained in the YAML files processed by __virtual__
     '''
     __data__ = {}
     for profile, data in data_list:
-        if show_profile:
-            _merge_yaml(__data__, data, profile)
-        else:
-            _merge_yaml(__data__, data)
+        _merge_yaml(__data__, data, profile)
     __tags__ = _get_tags(__data__)
 
     if debug:

--- a/hubblestack_nova/stat.py
+++ b/hubblestack_nova/stat.py
@@ -118,63 +118,6 @@ def audit(data_list, tags, verbose=False, show_profile=False, debug=False):
                 else:
                     ret['Failure'].append(tag_data)
 
-    failure = []
-    success = []
-    controlled = []
-
-    if not verbose:
-        # Pull out just the tag and description
-        tags_descriptions = set()
-
-        for tag_data in ret['Failure']:
-            tag = tag_data['tag']
-            description = tag_data.get('description')
-            if (tag, description) not in tags_descriptions:
-                failure.append({tag: description})
-                tags_descriptions.add((tag, description))
-
-        tags_descriptions = set()
-
-        for tag_data in ret['Success']:
-            tag = tag_data['tag']
-            description = tag_data.get('description')
-            if (tag, description) not in tags_descriptions:
-                success.append({tag: description})
-                tags_descriptions.add((tag, description))
-
-        control_reasons = set()
-
-        for tag_data in ret['Controlled']:
-            tag = tag_data['tag']
-            description = tag_data.get('description')
-            control_reason = tag_data.get('control', '')
-            if (tag, description, control_reason) not in control_reasons:
-                tag_dict = {'description': description,
-                        'control': control_reason}
-                controlled.append({tag: tag_dict})
-                control_reasons.add((tag, description, control_reason))
-
-    else:
-        # Format verbose output as single-key dictionaries with tag as key
-        for tag_data in ret['Failure']:
-            tag = tag_data['tag']
-            failure.append({tag: tag_data})
-
-        for tag_data in ret['Success']:
-            tag = tag_data['tag']
-            success.append({tag: tag_data})
-
-        for tag_data in ret['Controlled']:
-            tag = tag_data['tag']
-            controlled.append({tag: tag_data})
-
-    ret['Controlled'] = controlled
-    ret['Success'] = success
-    ret['Failure'] = failure
-
-    if not ret['Controlled']:
-        ret.pop('Controlled')
-
     return ret
 
 

--- a/hubblestack_nova/sysctl.py
+++ b/hubblestack_nova/sysctl.py
@@ -49,16 +49,13 @@ def __virtual__():
     return True
 
 
-def audit(data_list, tags, verbose=False, show_profile=False, debug=False):
+def audit(data_list, tags, debug=False):
     '''
     Run the sysctl audits contained in the YAML files processed by __virtual__
     '''
     __data__ = {}
     for profile, data in data_list:
-        if show_profile:
-            _merge_yaml(__data__, data, profile)
-        else:
-            _merge_yaml(__data__, data)
+        _merge_yaml(__data__, data, profile)
     __tags__ = _get_tags(__data__)
 
     if debug:

--- a/hubblestack_nova/sysctl.py
+++ b/hubblestack_nova/sysctl.py
@@ -91,63 +91,6 @@ def audit(data_list, tags, verbose=False, show_profile=False, debug=False):
             else:
                 ret['Failure'].append(tag_data)
 
-    failure = []
-    success = []
-    controlled = []
-
-    if not verbose:
-        # Pull out just the tag and description
-        tags_descriptions = set()
-
-        for tag_data in ret['Failure']:
-            tag = tag_data['tag']
-            description = tag_data.get('description')
-            if (tag, description) not in tags_descriptions:
-                failure.append({tag: description})
-                tags_descriptions.add((tag, description))
-
-        tags_descriptions = set()
-
-        for tag_data in ret['Success']:
-            tag = tag_data['tag']
-            description = tag_data.get('description')
-            if (tag, description) not in tags_descriptions:
-                success.append({tag: description})
-                tags_descriptions.add((tag, description))
-
-        control_reasons = set()
-
-        for tag_data in ret['Controlled']:
-            tag = tag_data['tag']
-            control_reason = tag_data.get('control', '')
-            description = tag_data.get('description')
-            if (tag, description, control_reason) not in control_reasons:
-                tag_dict = {'description': description,
-                        'control': control_reason}
-                controlled.append({tag: tag_dict})
-                control_reasons.add((tag, description, control_reason))
-
-    else:
-        # Format verbose output as single-key dictionaries with tag as key
-        for tag_data in ret['Failure']:
-            tag = tag_data['tag']
-            failure.append({tag: tag_data})
-
-        for tag_data in ret['Success']:
-            tag = tag_data['tag']
-            success.append({tag: tag_data})
-
-        for tag_data in ret['Controlled']:
-            tag = tag_data['tag']
-            controlled.append({tag: tag_data})
-
-    ret['Controlled'] = controlled
-    ret['Success'] = success
-    ret['Failure'] = failure
-
-    if not ret['Controlled']:
-        ret.pop('Controlled')
-
     return ret
 
 

--- a/hubblestack_nova/win_auditpol.py
+++ b/hubblestack_nova/win_auditpol.py
@@ -25,7 +25,7 @@ def __virtual__():
     return True
 
 
-def audit(data_list, tags, verbose=False, show_profile=False, debug=False):
+def audit(data_list, tags, debug=False):
     '''
     Runs auditpol on the local machine and audits the return data
     with the CIS yaml processed by __virtual__
@@ -33,10 +33,7 @@ def audit(data_list, tags, verbose=False, show_profile=False, debug=False):
     __data__ = {}
     __auditdata__ = _auditpol_import()
     for profile, data in data_list:
-        if show_profile:
-            _merge_yaml(__data__, data, profile)
-        else:
-            _merge_yaml(__data__, data)
+        _merge_yaml(__data__, data, profile)
     __tags__ = _get_tags(__data__)
     if debug:
         log.debug('auditpol audit __data__:')

--- a/hubblestack_nova/win_auditpol.py
+++ b/hubblestack_nova/win_auditpol.py
@@ -75,63 +75,6 @@ def audit(data_list, tags, verbose=False, show_profile=False, debug=False):
                         log.debug('When trying to audit the advanced auditpol section,'
                                   ' the yaml contained incorrect data for the key')
 
-    failure = []
-    success = []
-    controlled = []
-
-    if not verbose:
-        # Pull out just the tag and description
-        tags_descriptions = set()
-
-        for tag_data in ret['Failure']:
-            tag = tag_data['tag']
-            description = tag_data.get('description')
-            if (tag, description) not in tags_descriptions:
-                failure.append({tag: description})
-                tags_descriptions.add((tag, description))
-
-        tags_descriptions = set()
-
-        for tag_data in ret['Success']:
-            tag = tag_data['tag']
-            description = tag_data.get('description')
-            if (tag, description) not in tags_descriptions:
-                success.append({tag: description})
-                tags_descriptions.add((tag, description))
-
-        control_reasons = set()
-
-        for tag_data in ret['Controlled']:
-            tag = tag_data['tag']
-            control_reason = tag_data.get('control', '')
-            description = tag_data.get('description')
-            if (tag, description, control_reason) not in tags_descriptions:
-                tag_dict = {'description': description,
-                            'control': control_reason}
-                controlled.append({tag: description})
-                control_reasons.add((tag, description, control_reason))
-
-    else:
-        # Format verbose output as single-key dictionaries with tag as key
-        for tag_data in ret['Failure']:
-            tag = tag_data['tag']
-            failure.append({tag: tag_data})
-
-        for tag_data in ret['Success']:
-            tag = tag_data['tag']
-            success.append({tag: tag_data})
-
-        for tag_data in ret['Controlled']:
-            tag = tag_data['tag']
-            controlled.append({tag: tag_data})
-
-    ret['Controlled'] = controlled
-    ret['Success'] = success
-    ret['Failure'] = failure
-
-    if not ret['Controlled']:
-        ret.pop('Controlled')
-
     return ret
 
 

--- a/hubblestack_nova/win_firewall.py
+++ b/hubblestack_nova/win_firewall.py
@@ -76,63 +76,6 @@ def audit(data_list, tags, verbose=False, show_profile=False, debug=False):
                         log.debug('When trying to audit the firewall section,'
                                   ' the yaml contained incorrect data for the key')
 
-    failure = []
-    success = []
-    controlled = []
-
-    if not verbose:
-        # Pull out just the tag and description
-        tags_descriptions = set()
-
-        for tag_data in ret['Failure']:
-            tag = tag_data['tag']
-            description = tag_data.get('description')
-            if (tag, description) not in tags_descriptions:
-                failure.append({tag: description})
-                tags_descriptions.add((tag, description))
-
-        tags_descriptions = set()
-
-        for tag_data in ret['Success']:
-            tag = tag_data['tag']
-            description = tag_data.get('description')
-            if (tag, description) not in tags_descriptions:
-                success.append({tag: description})
-                tags_descriptions.add((tag, description))
-
-        control_reasons = set()
-
-        for tag_data in ret['Controlled']:
-            tag = tag_data['tag']
-            control_reason = tag_data.get('control', '')
-            description = tag_data.get('description')
-            if (tag, description, control_reason) not in tags_descriptions:
-                tag_dict = {'description': description,
-                            'control': control_reason}
-                controlled.append({tag: description})
-                control_reasons.add((tag, description, control_reason))
-
-    else:
-        # Format verbose output as single-key dictionaries with tag as key
-        for tag_data in ret['Failure']:
-            tag = tag_data['tag']
-            failure.append({tag: tag_data})
-
-        for tag_data in ret['Success']:
-            tag = tag_data['tag']
-            success.append({tag: tag_data})
-
-        for tag_data in ret['Controlled']:
-            tag = tag_data['tag']
-            controlled.append({tag: tag_data})
-
-    ret['Controlled'] = controlled
-    ret['Success'] = success
-    ret['Failure'] = failure
-
-    if not ret['Controlled']:
-        ret.pop('Controlled')
-
     return ret
 
 

--- a/hubblestack_nova/win_firewall.py
+++ b/hubblestack_nova/win_firewall.py
@@ -25,7 +25,7 @@ def __virtual__():
     return True
 
 
-def audit(data_list, tags, verbose=False, show_profile=False, debug=False):
+def audit(data_list, tags, debug=False):
     '''
     Runs auditpol on the local machine and audits the return data
     with the CIS yaml processed by __virtual__
@@ -33,10 +33,7 @@ def audit(data_list, tags, verbose=False, show_profile=False, debug=False):
     __data__ = {}
     __firewalldata__ = _import_firewall()
     for profile, data in data_list:
-        if show_profile:
-            _merge_yaml(__data__, data, profile)
-        else:
-            _merge_yaml(__data__, data)
+        _merge_yaml(__data__, data, profile)
     __tags__ = _get_tags(__data__)
     if debug:
         log.debug('firewall audit __data__:')

--- a/hubblestack_nova/win_gp.py
+++ b/hubblestack_nova/win_gp.py
@@ -75,63 +75,6 @@ def audit(data_list, tags, verbose=False, show_profile=False, debug=False):
                         log.debug('When trying to audit the firewall section,'
                                   ' the yaml contained incorrect data for the key')
 
-    failure = []
-    success = []
-    controlled = []
-
-    if not verbose:
-        # Pull out just the tag and description
-        tags_descriptions = set()
-
-        for tag_data in ret['Failure']:
-            tag = tag_data['tag']
-            description = tag_data.get('description')
-            if (tag, description) not in tags_descriptions:
-                failure.append({tag: description})
-                tags_descriptions.add((tag, description))
-
-        tags_descriptions = set()
-
-        for tag_data in ret['Success']:
-            tag = tag_data['tag']
-            description = tag_data.get('description')
-            if (tag, description) not in tags_descriptions:
-                success.append({tag: description})
-                tags_descriptions.add((tag, description))
-
-        control_reasons = set()
-
-        for tag_data in ret['Controlled']:
-            tag = tag_data['tag']
-            control_reason = tag_data.get('control', '')
-            description = tag_data.get('description')
-            if (tag, description, control_reason) not in tags_descriptions:
-                tag_dict = {'description': description,
-                            'control': control_reason}
-                controlled.append({tag: description})
-                control_reasons.add((tag, description, control_reason))
-
-    else:
-        # Format verbose output as single-key dictionaries with tag as key
-        for tag_data in ret['Failure']:
-            tag = tag_data['tag']
-            failure.append({tag: tag_data})
-
-        for tag_data in ret['Success']:
-            tag = tag_data['tag']
-            success.append({tag: tag_data})
-
-        for tag_data in ret['Controlled']:
-            tag = tag_data['tag']
-            controlled.append({tag: tag_data})
-
-    ret['Controlled'] = controlled
-    ret['Success'] = success
-    ret['Failure'] = failure
-
-    if not ret['Controlled']:
-        ret.pop('Controlled')
-
     return ret
 
 

--- a/hubblestack_nova/win_gp.py
+++ b/hubblestack_nova/win_gp.py
@@ -25,7 +25,7 @@ def __virtual__():
     return True
 
 
-def audit(data_list, tags, verbose=False, show_profile=False, debug=False):
+def audit(data_list, tags, debug=False):
     '''
     Runs auditpol on the local machine and audits the return data
     with the CIS yaml processed by __virtual__
@@ -33,10 +33,7 @@ def audit(data_list, tags, verbose=False, show_profile=False, debug=False):
     __data__ = {}
     __gpdata__ = _get_gp_templates()
     for profile, data in data_list:
-        if show_profile:
-            _merge_yaml(__data__, data, profile)
-        else:
-            _merge_yaml(__data__, data)
+        _merge_yaml(__data__, data, profile)
     __tags__ = _get_tags(__data__)
     if debug:
         log.debug('firewall audit __data__:')

--- a/hubblestack_nova/win_pkg.py
+++ b/hubblestack_nova/win_pkg.py
@@ -25,7 +25,7 @@ def __virtual__():
     return True
 
 
-def audit(data_list, tags, verbose=False, show_profile=False, debug=False):
+def audit(data_list, tags, debug=False):
     '''
     Runs auditpol on the local machine and audits the return data
     with the CIS yaml processed by __virtual__
@@ -37,10 +37,7 @@ def audit(data_list, tags, verbose=False, show_profile=False, debug=False):
         __salt__['pkg.refresh_db']()
         __pkgdata__ = __salt__['pkg.list_pkgs']()
     for profile, data in data_list:
-        if show_profile:
-            _merge_yaml(__data__, data, profile)
-        else:
-            _merge_yaml(__data__, data)
+        _merge_yaml(__data__, data, profile)
     __tags__ = _get_tags(__data__)
     if debug:
         log.debug('package audit __data__:')

--- a/hubblestack_nova/win_pkg.py
+++ b/hubblestack_nova/win_pkg.py
@@ -78,63 +78,6 @@ def audit(data_list, tags, verbose=False, show_profile=False, debug=False):
                     else:
                         ret['Failure'].append(tag_data)
 
-    failure = []
-    success = []
-    controlled = []
-
-    if not verbose:
-        # Pull out just the tag and description
-        tags_descriptions = set()
-
-        for tag_data in ret['Failure']:
-            tag = tag_data['tag']
-            description = tag_data.get('description')
-            if (tag, description) not in tags_descriptions:
-                failure.append({tag: description})
-                tags_descriptions.add((tag, description))
-
-        tags_descriptions = set()
-
-        for tag_data in ret['Success']:
-            tag = tag_data['tag']
-            description = tag_data.get('description')
-            if (tag, description) not in tags_descriptions:
-                success.append({tag: description})
-                tags_descriptions.add((tag, description))
-
-        control_reasons = set()
-
-        for tag_data in ret['Controlled']:
-            tag = tag_data['tag']
-            control_reason = tag_data.get('control', '')
-            description = tag_data.get('description')
-            if (tag, description, control_reason) not in tags_descriptions:
-                tag_dict = {'description': description,
-                            'control': control_reason}
-                controlled.append({tag: description})
-                control_reasons.add((tag, description, control_reason))
-
-    else:
-        # Format verbose output as single-key dictionaries with tag as key
-        for tag_data in ret['Failure']:
-            tag = tag_data['tag']
-            failure.append({tag: tag_data})
-
-        for tag_data in ret['Success']:
-            tag = tag_data['tag']
-            success.append({tag: tag_data})
-
-        for tag_data in ret['Controlled']:
-            tag = tag_data['tag']
-            controlled.append({tag: tag_data})
-
-    ret['Controlled'] = controlled
-    ret['Success'] = success
-    ret['Failure'] = failure
-
-    if not ret['Controlled']:
-        ret.pop('Controlled')
-
     return ret
 
 

--- a/hubblestack_nova/win_reg.py
+++ b/hubblestack_nova/win_reg.py
@@ -24,17 +24,14 @@ def __virtual__():
     return True
 
 
-def audit(data_list, tags, verbose=False, show_profile=False, debug=False):
+def audit(data_list, tags, debug=False):
     '''
     Runs auditpol on the local machine and audits the return data
     with the CIS yaml processed by __virtual__
     '''
     __data__ = {}
     for profile, data in data_list:
-        if show_profile:
-            _merge_yaml(__data__, data, profile)
-        else:
-            _merge_yaml(__data__, data)
+        _merge_yaml(__data__, data, profile)
     __tags__ = _get_tags(__data__)
     if debug:
         log.debug('registry audit __data__:')

--- a/hubblestack_nova/win_reg.py
+++ b/hubblestack_nova/win_reg.py
@@ -89,64 +89,6 @@ def audit(data_list, tags, verbose=False, show_profile=False, debug=False):
                         tag_data['value_found'] = None
                         ret['Failure'].append(tag_data)
 
-
-    failure = []
-    success = []
-    controlled = []
-
-    if not verbose:
-        # Pull out just the tag and description
-        tags_descriptions = set()
-
-        for tag_data in ret['Failure']:
-            tag = tag_data['tag']
-            description = tag_data.get('description')
-            if (tag, description) not in tags_descriptions:
-                failure.append({tag: description})
-                tags_descriptions.add((tag, description))
-
-        tags_descriptions = set()
-
-        for tag_data in ret['Success']:
-            tag = tag_data['tag']
-            description = tag_data.get('description')
-            if (tag, description) not in tags_descriptions:
-                success.append({tag: description})
-                tags_descriptions.add((tag, description))
-
-        control_reasons = set()
-
-        for tag_data in ret['Controlled']:
-            tag = tag_data['tag']
-            control_reason = tag_data.get('control', '')
-            description = tag_data.get('description')
-            if (tag, description, control_reason) not in tags_descriptions:
-                tag_dict = {'description': description,
-                            'control': control_reason}
-                controlled.append({tag: description})
-                control_reasons.add((tag, description, control_reason))
-
-    else:
-        # Format verbose output as single-key dictionaries with tag as key
-        for tag_data in ret['Failure']:
-            tag = tag_data['tag']
-            failure.append({tag: tag_data})
-
-        for tag_data in ret['Success']:
-            tag = tag_data['tag']
-            success.append({tag: tag_data})
-
-        for tag_data in ret['Controlled']:
-            tag = tag_data['tag']
-            controlled.append({tag: tag_data})
-
-    ret['Controlled'] = controlled
-    ret['Success'] = success
-    ret['Failure'] = failure
-
-    if not ret['Controlled']:
-        ret.pop('Controlled')
-
     return ret
 
 

--- a/hubblestack_nova/win_secedit.py
+++ b/hubblestack_nova/win_secedit.py
@@ -95,63 +95,6 @@ def audit(data_list, tags, verbose=False, show_profile=False, debug=False):
                     else:
                         ret['Failure'].append(tag_data)
 
-    failure = []
-    success = []
-    controlled = []
-
-    if not verbose:
-        # Pull out just the tag and description
-        tags_descriptions = set()
-
-        for tag_data in ret['Failure']:
-            tag = tag_data['tag']
-            description = tag_data.get('description')
-            if (tag, description) not in tags_descriptions:
-                failure.append({tag: description})
-                tags_descriptions.add((tag, description))
-
-        tags_descriptions = set()
-
-        for tag_data in ret['Success']:
-            tag = tag_data['tag']
-            description = tag_data.get('description')
-            if (tag, description) not in tags_descriptions:
-                success.append({tag: description})
-                tags_descriptions.add((tag, description))
-
-        control_reasons = set()
-
-        for tag_data in ret['Controlled']:
-            tag = tag_data['tag']
-            control_reason = tag_data.get('control', '')
-            description = tag_data.get('description')
-            if (tag, description, control_reason) not in tags_descriptions:
-                tag_dict = {'description': description,
-                            'control': control_reason}
-                controlled.append({tag: description})
-                control_reasons.add((tag, description, control_reason))
-
-    else:
-        # Format verbose output as single-key dictionaries with tag as key
-        for tag_data in ret['Failure']:
-            tag = tag_data['tag']
-            failure.append({tag: tag_data})
-
-        for tag_data in ret['Success']:
-            tag = tag_data['tag']
-            success.append({tag: tag_data})
-
-        for tag_data in ret['Controlled']:
-            tag = tag_data['tag']
-            controlled.append({tag: tag_data})
-
-    ret['Controlled'] = controlled
-    ret['Success'] = success
-    ret['Failure'] = failure
-
-    if not ret['Controlled']:
-        ret.pop('Controlled')
-
     return ret
 
 

--- a/hubblestack_nova/win_secedit.py
+++ b/hubblestack_nova/win_secedit.py
@@ -30,7 +30,7 @@ def __virtual__():
     return True
 
 
-def audit(data_list, tags, verbose=False, show_profile=False, debug=False):
+def audit(data_list, tags, debug=False):
     '''
     Runs secedit on the local machine and audits the return data
     with the CIS yaml processed by __virtual__
@@ -39,10 +39,7 @@ def audit(data_list, tags, verbose=False, show_profile=False, debug=False):
     __secdata__ = _secedit_export()
     __sidaccounts__ = _get_account_sid()
     for profile, data in data_list:
-        if show_profile:
-            _merge_yaml(__data__, data, profile)
-        else:
-            _merge_yaml(__data__, data)
+        _merge_yaml(__data__, data, profile)
     __tags__ = _get_tags(__data__)
     if debug:
         log.debug('secedit audit __data__:')


### PR DESCRIPTION
This PR moves the duplicate formatting code from the audit modules into hubble.py.

Other changes:
 - Deprecate the show_profile kwarg by always including that information
 - Deprecate the debug kwarg by using TRACE level logging for that information
 - Consistently calculates the compliance level whether verbose is True or False